### PR TITLE
Updating repo in Travis link and adding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ Regulations Parser
 This library/tool parses federal regulations (either plain text or XML) and
 much of their associated content. It can write the results to JSON files, an
 API, or even a git repository. The parser works hand-in-hand with
-regulations-core, an API for hosting the parsed regulations and
-regulation-site, a front-end for the data structures generated.
+[regulations-core](https://github.com/eregs/regulations-core), an API for hosting the parsed regulations and
+[regulation-site](https://github.com/eregs/regulations-site), a front-end for the data structures generated.
 
 This repository is part of a larger project. To read about it, please see 
 [https://eregs.github.io/](https://eregs.github.io/).
 
 ## Status
-[![Build Status](https://travis-ci.org/18F/regulations-parser.png)](https://travis-ci.org/18F/regulations-parser)
+[![Build Status](https://travis-ci.org/eregs/regulations-parser.png)](https://travis-ci.org/eregs/regulations-parser)
 [![Coverage Status](https://coveralls.io/repos/18F/regulations-parser/badge.svg?branch=master&service=github)](https://coveralls.io/github/18F/regulations-parser?branch=master)
 
 ## Docs
 
-See [Read the Docs](https://eregs-parser.readthedocs.org/) for setup,
+See [eregs-parser on Read the Docs](https://eregs-parser.readthedocs.org/) for setup,
 architecture, and maintenance docs.
 


### PR DESCRIPTION
The Travis "build status" badge was broken since it was referencing the old org name, so I updated that. I also added links to regulations-core and regulations-site for easy reference.