### PR TITLE
Parse intro paragraphs

### DIFF
--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -236,6 +236,9 @@ class NoticeXML(XMLWrapper):
         :returns: Grouped & sorted list.
         """
         refs = refs or []
+        # Convert everything into strings
+        refs = [dict(title=str(r["title"]), part=str(r["part"])) for r in refs]
+
         # Group parts by title:
         refd = {r["title"]: [] for r in refs}
         for ref in refs:

--- a/tests/notice_preamble_tests.py
+++ b/tests/notice_preamble_tests.py
@@ -11,6 +11,12 @@ class NoticePreambleTests(TestCase):
         """End-to-end test for parsing a notice preamble"""
         with XMLBuilder("ROOT") as ctx:
             ctx.P("ignored content")
+            with ctx.SUM():
+                ctx.HD("SUMMARY:")
+                ctx.P("Out of order summary")
+            with ctx.AGY():
+                ctx.HD("AGENCY:")
+                ctx.P("Agency name here.")
             with ctx.SUPLINF():
                 ctx.HED("Supp Inf")
                 ctx.P("P1")
@@ -36,6 +42,13 @@ class NoticePreambleTests(TestCase):
 
         self.assertEqual(root.label, ['vvv_yyy'])
         self.assertEqual(root.title, 'Supp Inf')
+        self.assertEqual(root.child_labels, ['intro', 'p1', 'p2', 'I', 'II'])
+
+        # We maintain the order presented
+        self.assertEqual(root['intro']['p1'].title, 'SUMMARY:')
+        self.assertEqual(root['intro']['p1'].text, 'Out of order summary')
+        self.assertEqual(root['intro']['p2'].title, 'AGENCY:')
+        self.assertEqual(root['intro']['p2'].text, 'Agency name here.')
         self.assertEqual(root['p1'].text, 'P1')
         self.assertEqual(root['p2'].text, 'P2')
         self.assertEqual(root['I'].title, 'I. H1')

--- a/tests/notice_xml_tests.py
+++ b/tests/notice_xml_tests.py
@@ -492,12 +492,12 @@ class NoticeXMLTests(TestCase):
             xml = notice_xml.NoticeXML(ctx.xml)
             result = xml.set_cfr_refs(refs=refs)
             self.assertEquals(expected, result, xml.cfr_refs)
-        refs = [
-            {"title": "40", "part": "300"},
+        refs = [    # Mix of ints and strings
+            {"title": 40, "part": 300},
             {"title": "41", "part": "210"},
-            {"title": "40", "part": "301"},
+            {"title": 40, "part": "301"},
             {"title": "40", "part": "302"},
-            {"title": "40", "part": "303"},
+            {"title": "40", "part": 303},
             {"title": "42", "part": "302"},
             {"title": "42", "part": "303"}
         ]


### PR DESCRIPTION
Previously, we had only considered the "supplemental info" section. This patch
expands that logic a bit, inserting an "intro" node which includes agency,
action, summary, etc. information

Also fixes a bug w/ cfr titles. Resolves eregs/notice-and-comment#157

This doesn't account for the "meta" data about the notice yet.