### PR TITLE
Handle integer values in federal register json.

### DIFF
--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -215,7 +215,7 @@ class NoticeXML(XMLWrapper):
         Return a list of TitlePartsRef objects grouped by title and
         sorted, for example::
 
-            [{"title": "0", "part": "23"}, {"title": "0", "part": "17"}]
+            [{"title": 0, "part": 23}, {"title": 0, "part": 17}]
 
         Becomes::
 
@@ -242,19 +242,17 @@ class NoticeXML(XMLWrapper):
             refd[ref["title"]].append(ref["part"])
         refs = [{u"title": k, "parts": refd[k]} for k in refd]
         # Sort parts and sort list by title:
-        refs = [TitlePartsRef(r["title"],
-                              sorted(r["parts"], key=lambda x: int(x)))
+        refs = [TitlePartsRef(r["title"], sorted(r["parts"], key=int))
                 for r in refs]
         refs = sorted(refs, key=lambda x: int(x.title))
 
         refs_el = etree.Element("EREGS_CFR_REFS")
         for ref in refs:
             el = etree.SubElement(refs_el, "EREGS_CFR_TITLE_REF",
-                                  title=ref.title)
+                                  title=str(ref.title))
             for part in ref.parts:
-                etree.SubElement(el, "EREGS_CFR_PART_REF", part=part)
+                etree.SubElement(el, "EREGS_CFR_PART_REF", part=str(part))
         self.xml.insert(0, refs_el)
-        return refs
 
     def derive_closing_date(self):
         """Attempt to parse comment closing date from DATES tags. Returns a

--- a/tests/notice_xml_tests.py
+++ b/tests/notice_xml_tests.py
@@ -490,16 +490,16 @@ class NoticeXMLTests(TestCase):
         def _reftest(refs, expected):
             ctx = XMLBuilder("ROOT").P("filler")
             xml = notice_xml.NoticeXML(ctx.xml)
-            result = xml.set_cfr_refs(refs=refs)
-            self.assertEquals(expected, result, xml.cfr_refs)
+            xml.set_cfr_refs(refs=refs)
+            self.assertEquals(expected, xml.cfr_refs)
         refs = [
-            {"title": "40", "part": "300"},
-            {"title": "41", "part": "210"},
-            {"title": "40", "part": "301"},
-            {"title": "40", "part": "302"},
-            {"title": "40", "part": "303"},
-            {"title": "42", "part": "302"},
-            {"title": "42", "part": "303"}
+            {"title": 40, "part": 300},
+            {"title": 41, "part": 210},
+            {"title": 40, "part": 301},
+            {"title": 40, "part": 302},
+            {"title": 40, "part": 303},
+            {"title": 42, "part": 302},
+            {"title": 42, "part": 303}
         ]
         expected = [
             notice_xml.TitlePartsRef(title="40",
@@ -510,11 +510,11 @@ class NoticeXMLTests(TestCase):
         _reftest(refs, expected)
         _reftest([], [])
         refs = [
-            {"title": "42", "part": "302"},
-            {"title": "42", "part": "303"},
-            {"title": "40", "part": "330"},
-            {"title": "41", "part": "210"},
-            {"title": "40", "part": "300"},
+            {"title": 42, "part": 302},
+            {"title": 42, "part": 303},
+            {"title": 40, "part": 330},
+            {"title": 41, "part": 210},
+            {"title": 40, "part": 300},
         ]
         expected = [
             notice_xml.TitlePartsRef(title="40", parts=["300", "330"]),


### PR DESCRIPTION
The json returned by `federalregister.meta_data` uses integers for cfr
titles and parts, but our code and tests expect to receive strings. This
patch updates the logic around titles and parts to handle ints instead.
Note: sorts continue to cast to ints in case we ever happen to receive
strings.

To verify, check that parsing a preamble works with this patch (and errors otherwise). BTW, this reminds me that we might want to get this into our integration tests--same applies to anything else we add to -parser that isn't already covered.

cc @cmc333333 @tadhg-ohiggins 