### PR TITLE
Cleanup xml-munging functions

### DIFF
--- a/regparser/tree/xml_parser/tree_utils.py
+++ b/regparser/tree/xml_parser/tree_utils.py
@@ -1,9 +1,10 @@
 # vim: set encoding=utf-8
 from copy import deepcopy
-import HTMLParser
+from HTMLParser import HTMLParser
 from itertools import chain
 
-from regparser.tree.depth import markers as mtypes
+from lxml import etree
+
 from regparser.tree.priority_stack import PriorityStack
 
 
@@ -110,9 +111,8 @@ def get_node_text(node, add_spaces=False):
     _superscript_to_text(node, add_spaces)
     _footnotes_to_text(node, add_spaces)
 
-    parts = [node.text] +\
-        list(chain(*([c.text, c.tail] for c in node.getchildren()))) +\
-        [node.tail]
+    parts = [node.text] + list(
+        chain(*([c.text, c.tail] for c in node.getchildren())))
 
     final_text = ''
     for part in filter(bool, parts):
@@ -120,23 +120,20 @@ def get_node_text(node, add_spaces=False):
     return final_text.strip()
 
 
+_tag_black_list = ('PRTPAGE', )
+
+
 def get_node_text_tags_preserved(node):
-    """ Given an XML node, generate text from the node, skipping the PRTPAGE
-    tag. """
+    """Get the body of an XML node as a string, avoiding a specific blacklist
+    of bad tags."""
+    node = deepcopy(node)
+    etree.strip_tags(node, *_tag_black_list)
+    node_text = etree.tostring(node)
 
-    html_parser = HTMLParser.HTMLParser()
+    # Remove the wrapping tag
+    end_open_tag = node_text.index('>')
+    start_close_tag = node_text.rindex('<')
+    node_text = node_text[end_open_tag + 1:start_close_tag]
 
-    if node.text:
-        node_text = node.text
-    else:
-        node_text = ''
-
-    for c in node:
-        if c.tag == 'E':
-            # xlmns non-sense makes me do this.
-            node_text += mtypes.emphasize(c.text)
-        if c.tail is not None:
-            node_text += c.tail
-
-    node_text = html_parser.unescape(node_text)
+    node_text = HTMLParser().unescape(node_text)
     return node_text

--- a/regparser/tree/xml_parser/tree_utils.py
+++ b/regparser/tree/xml_parser/tree_utils.py
@@ -123,17 +123,15 @@ def get_node_text(node, add_spaces=False):
 _tag_black_list = ('PRTPAGE', )
 
 
-def get_node_text_tags_preserved(node):
+def get_node_text_tags_preserved(xml_node):
     """Get the body of an XML node as a string, avoiding a specific blacklist
     of bad tags."""
-    node = deepcopy(node)
-    etree.strip_tags(node, *_tag_black_list)
-    node_text = etree.tostring(node)
+    xml_node = deepcopy(xml_node)
+    etree.strip_tags(xml_node, *_tag_black_list)
 
     # Remove the wrapping tag
-    end_open_tag = node_text.index('>')
-    start_close_tag = node_text.rindex('<')
-    node_text = node_text[end_open_tag + 1:start_close_tag]
+    node_text = xml_node.text or ''
+    node_text += ''.join(etree.tostring(child) for child in xml_node)
 
     node_text = HTMLParser().unescape(node_text)
     return node_text

--- a/tests/tree_utils_tests.py
+++ b/tests/tree_utils_tests.py
@@ -54,6 +54,10 @@ class TreeUtilsTest(unittest.TestCase):
         self.assert_transform_equality(
             '<P>(a) Fruit. Apples, and Pineapples</P>',
             '(a) Fruit. Apples, and Pineapples', *transforms)
+        self.assert_transform_equality(
+            '<P>(a) <E T="01">Other</E> tags: <PIGLATIN>oof</PIGLATIN></P>',
+            '(a) <E T="01">Other</E> tags: <PIGLATIN>oof</PIGLATIN>',
+            *transforms)
 
     def test_get_node_text(self):
         """Verify that the appropriate tags are removed, and, if requested,
@@ -105,6 +109,13 @@ class TreeUtilsTest(unittest.TestCase):
         self.assert_transform_equality(
             '<P>y = x<E T="52">0</E> + mx<SU>2</SU></P>',
             'y = x_{0} + mx^{2}', *no_space)
+
+    def test_get_node_text_no_tail(self):
+        """get_node_text should not include any "tail" present (e.g. if
+        processing part of a larger XML doc)"""
+        xml = etree.fromstring("<root>Some <p>paragraph</p> w/ tail</root>")
+        xml = xml.xpath("./p")[0]
+        self.assertEqual(tree_utils.get_node_text(xml), 'paragraph')
 
     def test_unwind_stack(self):
         level_one_n = Node(label=['272'])


### PR DESCRIPTION
While working on a now-shelved issue, I found that two tree_utils functions
did not work the way I expected. The `get_node_text` function was including
text outside of the parameter is was given (e.g. "this tail" in
`<p>text</p>this tail`). Further, the `get_node_text_tags_preserved` wasn't
actually preserving most tags. This patch replaces it with a simpler form
based on `lxml`'s `strip_tags`.

We should expect integration tests to fail, but the diffs should all make
sense.