### PR TITLE
Add install with Docker option

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,3 @@ docs/_build
 regparser.egg-info/
 
 .eregs_index/
-
-# eregs output
-/fr_cache.sqlite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2.7-alpine
+
+COPY ["regparser", "/app/src/"]
+COPY ["settings.py", "eregs.py", "requirements.txt", "setup.py", "/app/src/"]
+VOLUME ["/app/cache", "/app/output"]
+
+WORKDIR /app/src/
+RUN apk add --update libxslt libxml2-dev libxslt-dev musl-dev gcc git \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del --purge libxml2-dev libxslt-dev musl-dev gcc \
+    && rm -rf /var/cache/apk/*
+
+ENV PYTHONUNBUFFERED="1" \
+    EREGS_CACHE_DIR="/app/cache" \
+    EREGS_OUTPUT_DIR="/app/output"
+
+ENTRYPOINT ["eregs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7-alpine
 
-COPY ["regparser", "/app/src/"]
+COPY ["regparser", "/app/src/regparser/"]
 COPY ["settings.py", "eregs.py", "requirements.txt", "setup.py", "/app/src/"]
 VOLUME ["/app/cache", "/app/output"]
 

--- a/docs/deeper.rst
+++ b/docs/deeper.rst
@@ -150,11 +150,6 @@ generating diffs (currently an n:super:`2` operation). Generally, parsing will
 take less than ten minutes, but in the extreme example of reg Z, it currently
 requires several hours.
 
-There are a few methods to speed up this process. Installing
-``requests-cache`` will cache API-read calls (such as those made when calling
-the Federal Register). The cache lives in an sqlite database
-(``fr_cache.sqlite``), which can be safely removed without error.
-
 Parsing Error Example
 =====================
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,28 +23,31 @@ allow input/output via stdio, and prevent containers from hanging around in
 between executions. To do that, we recommend creating a wrapper script and
 executing the parser through that wrapper.
 
-For Linux and OS X, this looks like:
+For Linux and OS X, you could create a script, ``eregs.sh``, that looks like:
 
 .. code-block:: bash
 
-  # Make a shell script
-  echo '#!/bin/sh' > eregs
-  # The script will create a directory for the output
-  echo 'mkdir -p output' >> eregs
-  # It'll also create a placeholder local_settings.py, if none exists
-  echo 'touch local_settings.py' >> eregs
-  # The script will wrap the docker command with appropriate flags while
-  # passing in any arguments.
+  #!/bin/sh
+  # Create a directory for the output
+  mkdir -p output
+  # Create a placeholder local_settings.py, if none exists
+  touch local_settings.py
+  # Execute docker with appropriate flags while passing in any arguments.
   # --rm removes the container after execution
+  # -it makes the container interactive (particularly useful with --debug)
   # -v mounts volumes for cache, output, and copies in the local settings
-  echo 'docker run --rm -it -v eregs-cache:/app/cache -v $PWD/output:/app/output -v $PWD/local_settings.py:/app/code/local_settings.py eregs/parser $@' >> eregs
-  # Make the script executable
-  chmod +x eregs
+  docker run --rm -it -v eregs-cache:/app/cache -v $PWD/output:/app/output -v $PWD/local_settings.py:/app/code/local_settings.py eregs/parser $@
 
-To execute parsing commands, just run ``path/to/eregs`` in place of ``eregs``
-in future documentation. Leave off the final argument in ``pipeline`` and
-``write_to`` commands if you would like to see the results in the "output"
-directory.
+Remember to make that script executable:
+
+.. code-block:: bash
+
+  chmod +x eregs.sh
+
+To parse, run the wrapper script, ``path/to/eregs.sh``, instead of ``eregs``
+wherever instructed to in the rest of this documentation documentation. Also,
+leave off the final argument in ``pipeline`` and ``write_to`` commands if you
+would like to see the results in the "output" directory.
 
 -----------
 From Source

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -45,9 +45,9 @@ Remember to make that script executable:
   chmod +x eregs.sh
 
 To parse, run the wrapper script, ``path/to/eregs.sh``, instead of ``eregs``
-wherever instructed to in the rest of this documentation documentation. Also,
-leave off the final argument in ``pipeline`` and ``write_to`` commands if you
-would like to see the results in the "output" directory.
+wherever instructed to in the rest of this documentation. Also, leave off the
+final argument in ``pipeline`` and ``write_to`` commands if you would like to
+see the results in the "output" directory.
 
 -----------
 From Source

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,6 +2,54 @@
 Installation
 ============
 
+--------------
+Docker Install
+--------------
+
+For quick installation, consider installing from our
+`Docker image <https://hub.docker.com/r/eregs/parser/>`_.
+This image includes all of the relevant dependencies, wrapped up in a
+"container" for ease of installation. To run it, you'll need to have Docker
+installed, though the installation instructions for
+`Linux <https://docs.docker.com/linux/step_one/>`_,
+`Mac <https://docs.docker.com/mac/step_one/>`_, and
+`Windows <https://docs.docker.com/windows/step_one/>`_
+are relatively painless.
+
+To run with Docker, there are some nasty configuration details which we'd like
+to hide behind a cleaner interface. Specifically, we want to provide a simple
+mechanism for collecting output, keep a cache around in between executions,
+allow input/output via stdio, and prevent containers from hanging around in
+between executions. To do that, we recommend creating a wrapper script and
+executing the parser through that wrapper.
+
+For Linux and OS X, this looks like:
+
+.. code-block:: bash
+
+  # Make a shell script
+  echo '#!/bin/sh' > eregs
+  # The script will create a directory for the output
+  echo 'mkdir output' >> eregs
+  # It'll also create a placeholder local_settings.py, if none exists
+  echo 'touch local_settings.py' >> eregs
+  # The script will wrap the docker command with appropriate flags while
+  # passing in any arguments.
+  # --rm removes the container after execution
+  # -v mounts volumes for cache, output, and copies in the local settings
+  echo 'docker run --rm -it -v eregs-cache:/app/cache -v $PWD/output:/app/output -v $PWD/local_settings.py:/app/code/local_settings.py eregs/parser $@' >> eregs
+  # Make the script executable
+  chmod +x eregs
+
+To execute parsing commands, just run ``path/to/eregs`` in place of ``eregs``
+in future documentation. Leave off the final argument in ``pipeline`` and
+``write_to`` commands if you would like to see the results in the "output"
+directory.
+
+-----------
+From Source
+-----------
+
 Getting the Code and Development Libs
 =====================================
 
@@ -30,10 +78,12 @@ Get the required libraries
   cd regulations-parser
   pip install -r requirements.txt
 
+--------------
 Run the parser
-==============
+--------------
+
 Using ``pipeline``
-------------------
+==================
 
 .. code-block:: bash
 
@@ -50,6 +100,11 @@ Example:
 .. code-block:: bash
 
   eregs pipeline 27 447 /output/path
+
+**Warning** If using Docker and intending to write to the filesystem, remove
+the final parameter (``/output/path`` above). All output will be written to
+the "/app/output" directory, which is mounted as "output" if you are using a
+script as described above.
 
 ``pipeline`` pulls annual editions of regulations from the 
 `Government Printing Office <http://www.gpo.gov/fdsys/browse/collectionCfr.action>`_ and final rules from the 
@@ -72,7 +127,7 @@ JSON files will be written in that directory. See :ref:`output` for more.
 
 
 Settings
---------
+========
 
 All of the settings listed in ``settings.py`` can be overridden in a
 ``local_settings.py`` file. Current settings include:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,7 +30,7 @@ For Linux and OS X, this looks like:
   # Make a shell script
   echo '#!/bin/sh' > eregs
   # The script will create a directory for the output
-  echo 'mkdir output' >> eregs
+  echo 'mkdir -p output' >> eregs
   # It'll also create a placeholder local_settings.py, if none exists
   echo 'touch local_settings.py' >> eregs
   # The script will wrap the docker command with appropriate flags while

--- a/eregs.py
+++ b/eregs.py
@@ -8,11 +8,10 @@ import coloredlogs
 import click
 import ipdb
 import pyparsing
-import requests_cache   # @todo - replace with cache control
 
 from regparser import commands
 from regparser.commands.dependency_resolver import DependencyResolver
-from regparser.index import dependency
+from regparser.index import dependency, http_cache
 
 logger = logging.getLogger(__name__)
 DEFAULT_LOG_FORMAT = "%(asctime)s %(name)-40s %(message)s"
@@ -22,7 +21,7 @@ DEFAULT_LOG_FORMAT = "%(asctime)s %(name)-40s %(message)s"
 @click.option('--debug/--no-debug', default=False)
 def cli(debug):
     log_level = logging.INFO
-    requests_cache.install_cache('fr_cache', expire_after=60*60*24*3)  # 3 days
+    http_cache.install()
     if debug:
         log_level = logging.DEBUG
         sys.excepthook = lambda t, v, tb: ipdb.post_mortem(tb)

--- a/regparser/commands/clear.py
+++ b/regparser/commands/clear.py
@@ -6,16 +6,11 @@ import click
 from regparser.index import entry
 
 
-SQLITE_CACHE = 'fr_cache.sqlite'
-
-
 @click.command()
 @click.argument('path', nargs=-1)
-@click.option('--http-cache/--no-http-cache', default=False,
-              help="Clear HTTP request (FR, GPO, etc.). Defaults false")
-def clear(path, http_cache):
-    """Delete intermediate data. Only PATH arguments are cleared unless no
-    arguments are present, then everything is wiped.
+def clear(path):
+    """Delete intermediate and cache data. Only PATH arguments are cleared
+    unless no arguments are present, then everything is wiped.
 
     \b
     $ eregs clear                   # clears everything
@@ -30,6 +25,3 @@ def clear(path, http_cache):
             shutil.rmtree(path)
         else:
             click.echo("Warning: path does not exist: " + path)
-
-    if http_cache and os.path.exists(SQLITE_CACHE):
-        os.remove(SQLITE_CACHE)

--- a/regparser/commands/pipeline.py
+++ b/regparser/commands/pipeline.py
@@ -14,7 +14,7 @@ from regparser.commands.write_to import write_to
 @click.command()
 @click.argument('cfr_title', type=int)
 @click.argument('cfr_part', type=int)
-@click.argument('output')
+@click.argument('output', envvar='EREGS_OUTPUT_DIR')
 @click.option('--only-latest', is_flag=True, default=False,
               help="Don't derive history; use the latest annual edition")
 @click.option('--xml-ttl', type=int, default=60*60,

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -64,7 +64,7 @@ def write_preambles(client):
 
 
 @click.command()
-@click.argument('output')
+@click.argument('output', envvar='EREGS_OUTPUT_DIR')
 @click.option('--cfr_title', type=int, help="Limit to one CFR title")
 @click.option('--cfr_part', type=int, help="Limit to one CFR part")
 def write_to(output, cfr_title, cfr_part):

--- a/regparser/index/__init__.py
+++ b/regparser/index/__init__.py
@@ -1,1 +1,3 @@
-ROOT = '.eregs_index'
+import os
+
+ROOT = os.environ.get('EREGS_CACHE_DIR', '.eregs_index')

--- a/regparser/index/http_cache.py
+++ b/regparser/index/http_cache.py
@@ -1,0 +1,14 @@
+import os
+
+import requests_cache   # @todo - replace with cache control
+
+from . import ROOT
+
+
+PATH = os.path.join(ROOT, 'http_cache.sqlite')
+
+
+def install():
+    if not os.path.exists(ROOT):
+        os.makedirs(ROOT)
+    requests_cache.install_cache(PATH, expire_after=60*60*24*3)  # 3 days

--- a/tests/commands_clear_tests.py
+++ b/tests/commands_clear_tests.py
@@ -3,8 +3,9 @@ from unittest import TestCase
 
 from click.testing import CliRunner
 
+from regparser import index
 from regparser.commands.clear import clear
-from regparser.index import entry
+from regparser.index import entry, http_cache
 
 
 class CommandsClearTests(TestCase):
@@ -16,17 +17,14 @@ class CommandsClearTests(TestCase):
         with self.cli.isolated_filesystem():
             self.cli.invoke(clear)
 
-    def test_deletes_fr_cache(self):
+    def test_deletes_http_cache(self):
         with self.cli.isolated_filesystem():
-            open('fr_cache.sqlite', 'w').close()
-            self.assertTrue(os.path.exists('fr_cache.sqlite'))
+            os.makedirs(index.ROOT)
+            open(http_cache.PATH, 'w').close()
+            self.assertTrue(os.path.exists(http_cache.PATH))
 
-            # flag must be present
             self.cli.invoke(clear)
-            self.assertTrue(os.path.exists('fr_cache.sqlite'))
-
-            self.cli.invoke(clear, ['--http-cache'])
-            self.assertFalse(os.path.exists('fr_cache.sqlite'))
+            self.assertFalse(os.path.exists(http_cache.PATH))
 
     def test_deletes_index(self):
         with self.cli.isolated_filesystem():


### PR DESCRIPTION
Adds `Dockerfile` and instructions for using the built image to the docs. This image will contain all of the necessary libs (including the libxml junk, which has consistently been a pain point) to execute the parser. It moves around the HTTP cache to make this easier to run.

To see this in action, copy the wrapper shell script (described in the included docs) and execute:

```sh
./eregs pipeline 27 646
```

You'll see that a newly created "output" directory will become populated. Running the command again, you'll see that the index is maintained.