### PR TITLE
Add cfr prefix to sxs layers.

### DIFF
--- a/regparser/commands/sxs_layers.py
+++ b/regparser/commands/sxs_layers.py
@@ -46,5 +46,6 @@ def sxs_layers(cfr_title, cfr_part):
             notices = [sxs.read() for sxs in previous_sxs(
                         cfr_title, cfr_part, version_id)]
             layer_json = SectionBySection(tree, notices).build()
-            entry.Layer(cfr_title, cfr_part, version_id, 'analyses').write(
+            entry.Layer.cfr(
+                cfr_title, cfr_part, version_id, 'analyses').write(
                 layer_json)


### PR DESCRIPTION
Non-sxs layers are prefixed with document type, but sxs layers are not,
leading to errors on calling `write_to` without a cfr title and part
after building sxs layers. This patch prefixes sxs layers with the cfr
document type.