### PR TITLE
Revert assignment of preorder_idx to nodes

### DIFF
--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -4,7 +4,6 @@ import logging
 from regparser.api_writer import Client
 from regparser.commands import utils
 from regparser.index import entry
-from regparser.tree.struct import assign_preorder_index
 
 
 logger = logging.getLogger(__name__)
@@ -15,7 +14,6 @@ def write_trees(client, only_title, only_part):
                                            only_part):
         cfr_title, cfr_part, version_id = tree_entry.path
         content = tree_entry.read()
-        assign_preorder_index(content)
         client.regulation(cfr_part, version_id).write(content)
 
 
@@ -63,7 +61,6 @@ def write_diffs(client, only_title, only_part):
 def write_preambles(client):
     for doc_id in entry.Preamble():
         preamble = entry.Preamble(doc_id).read()
-        assign_preorder_index(preamble)
         client.preamble(doc_id).write(preamble)
 
 

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -205,11 +205,6 @@ def merge_duplicates(nodes):
         return nodes
 
 
-def assign_preorder_index(root_node):
-    for idx, node in enumerate(root_node.walk(lambda n: n)):
-        node.preorder_idx = idx
-
-
 def treeify(nodes):
     """Given a list of nodes, convert those nodes into the appropriate tree
     structure based on their labels. This assumes that all nodes will fall

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -106,36 +106,6 @@ class DepthTreeTest(TestCase):
         self.assertEqual(root.children[0],
                          struct.find_parent(root, 'root-1-b'))
 
-    def test_assign_preorder_indexes(self):
-        """
-                       n1(0)
-                      /    \
-                    n2(1)   n3(5)
-                      |
-                    n4(2)
-                  /   \
-               n5(3)   n6(4)
-        """
-        n1 = struct.Node("1")
-        n2 = struct.Node("2")
-        n3 = struct.Node("3")
-        n4 = struct.Node("4")
-        n5 = struct.Node("5")
-        n6 = struct.Node("6")
-
-        n1.children = [n2, n3]
-        n2.children = [n4]
-        n4.children = [n5, n6]
-
-        struct.assign_preorder_index(n1)
-
-        self.assertEqual(0, n1.preorder_idx)
-        self.assertEqual(1, n2.preorder_idx)
-        self.assertEqual(2, n4.preorder_idx)
-        self.assertEqual(3, n5.preorder_idx)
-        self.assertEqual(4, n6.preorder_idx)
-        self.assertEqual(5, n3.preorder_idx)
-
     def test_encode(self):
         n1 = struct.Node('texttext', [struct.Node(node_type='t')],
                          ['1', '2', '3'])


### PR DESCRIPTION
The existing lft id (assigned using the Modified Preorder Tree
Traversal algorithm) has been employed to allow preorder sorting.