### PR TITLE
Write preambles before writing layers

### DIFF
--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -81,8 +81,9 @@ def write_to(output, cfr_title, cfr_part):
                 cfr_title, cfr_part, output)
     client = Client(output)
     write_trees(client, cfr_title, cfr_part)
+    if cfr_title is None and cfr_part is None:
+        write_preambles(client)
+    # Note that layers must always be written _after_ the trees they reference
     write_layers(client, cfr_title, cfr_part)
     write_notices(client, cfr_title, cfr_part)
     write_diffs(client, cfr_title, cfr_part)
-    if cfr_title is None and cfr_part is None:
-        write_preambles(client)


### PR DESCRIPTION
We ran into an issue a bit before the most recent demo where layer data wasn't
available for the preamble on the new live site. The data _was_ available
locally. Unfortunately, the order-of-operations in the `write_to` command lead
the layers to be written before the preamble; the API needs to look up the
associated document (i.e. the preamble) when processing the layers, so no
layers were added.

This swaps the order so that trees (regulations and preambles) are written
before their layers