### PR TITLE
Add consistent ordering for external citations

### DIFF
--- a/regparser/layer/external_types.py
+++ b/regparser/layer/external_types.py
@@ -36,6 +36,7 @@ class FinderBase(object):
 def fdsys_url(**params):
     """Generate a URL to an FDSYS redirect"""
     params['year'] = params.get('year', 'mostrecent')
+    params = sorted(params.items())     # consistent encoding
     return 'http://api.fdsys.gov/link?{}'.format(urlencode(params))
 
 

--- a/regparser/layer/layer.py
+++ b/regparser/layer/layer.py
@@ -64,7 +64,7 @@ class Layer(object):
         for match in matches:
             text_to_matches[text[start_fn(match):end_fn(match)]].append(match)
 
-        for match_text, matches in text_to_matches.items():
+        for match_text, matches in sorted(text_to_matches.items()):
             locations, location = [], 0
             idx = text.find(match_text)
             while idx != -1:


### PR DESCRIPTION
* When generating the FDSYS URL, always order the parameters
* When generating the layer data, order the matches within a single node

Part of a series to make Python3 results match Python2. Split out into different PRs so that comparisons with existing data are easier to spot.