### PR TITLE
Replace all whitespace with single spaces

### DIFF
--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -131,31 +131,32 @@ def match_labels_and_changes(amendments, section_node):
     eliminate paragraphs that are just stars for positioning, for example.  """
     amended_labels = [a.label_id() for a in amendments]
 
-    amend_map = defaultdict(list)
+    amend_map = OrderedDict()
     for amend in amendments:
+        existing = amend_map.get(amend.label_id(), [])
         change = {'action': amend.action, 'amdpar_xml': amend.amdpar_xml}
         if amend.field is not None:
             change['field'] = amend.field
 
         if amend.action == 'MOVE':
             change['destination'] = amend.destination
-            amend_map[amend.label_id()].append(change)
+            amend_map[amend.label_id()] = existing + [change]
         elif amend.action == 'DELETE':
-            amend_map[amend.label_id()].append(change)
+            amend_map[amend.label_id()] = existing + [change]
         elif section_node is not None:
             node = struct.find(section_node, amend.label_id())
             if node is None:
                 candidate = find_misparsed_node(
                     section_node, amend.label, change, amended_labels)
                 if candidate:
-                    amend_map[amend.label_id()].append(candidate)
+                    amend_map[amend.label_id()] = existing + [candidate]
             else:
                 change['node'] = node
                 change['candidate'] = False
                 level2 = amend.tree_format_level2()
                 if level2 and node.is_section():
                     change['parent_label'] = level2
-                amend_map[amend.label_id()].append(change)
+                amend_map[amend.label_id()] = existing + [change]
 
     resolve_candidates(amend_map)
     return amend_map

--- a/regparser/tree/xml_parser/tree_utils.py
+++ b/regparser/tree/xml_parser/tree_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from copy import deepcopy
 from itertools import chain
+import re
 
 from lxml import etree
 from six.moves.html_parser import HTMLParser
@@ -103,6 +104,9 @@ def _footnotes_to_text(node, add_spaces):
         replace_xml_node_with_text(su, text)
 
 
+_whitespace = re.compile(u'\s+', re.UNICODE)    # aware of "thin" spaces, etc.
+
+
 def get_node_text(node, add_spaces=False):
     """ Extract all the text from an XML node (including the text of it's
     children). """
@@ -113,9 +117,10 @@ def get_node_text(node, add_spaces=False):
 
     parts = [node.text] + list(
         chain(*([c.text, c.tail] for c in node.getchildren())))
+    parts = [_whitespace.sub(' ', part) for part in parts if part]
 
     final_text = ''
-    for part in filter(bool, parts):
+    for part in parts:
         final_text = _combine_with_space(final_text, part, add_spaces)
     return final_text.strip()
 

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -443,12 +443,12 @@ class RegTextTest(TestCase):
         with XMLBuilder("SECTION", "\n\n") as ctx:
             ctx.SECTNO(u"§ 8675.309")
             ctx.SUBJECT("subsubsub")
-            ctx.P("   Some \n content\n")
+            ctx.P(u"   Some \n\u2009 content\n")
             ctx.P("(a) aaa")
             ctx.P("(b) bbb")
 
         node = reg_text.build_from_section('8675', ctx.xml)[0]
-        self.assertEqual(node.text, "Some \n content")
+        self.assertEqual(node.text, "Some content")
 
     def test_build_from_section_image(self):
         """We should process images (GPH/GID)"""


### PR DESCRIPTION
Also orders amendments. The amendment order shouldn't trip any flags during integration test (as the integration tests don't derive any amendment data). I suspect that the whitespace change will trip some alarms. I'm also curious whether it seems crazy.

Part of a series to make Python3 results match Python2. Split out into different PRs so that comparisons with existing data are easier to spot.