### PR TITLE
Ignore whitespace changes when diffing

### DIFF
--- a/regparser/diff/tree.py
+++ b/regparser/diff/tree.py
@@ -9,7 +9,7 @@ ADDED = 'added'
 MODIFIED = 'modified'
 DELETED = 'deleted'
 
-_whitespace = re.compile(u'\s+', re.UNICODE)    # aware of "thin" spaces, etc.
+_whitespace = re.compile(u'\s', re.UNICODE)    # aware of "thin" spaces, etc.
 
 
 def _local_text_changes(lhs, rhs):

--- a/regparser/diff/tree.py
+++ b/regparser/diff/tree.py
@@ -1,4 +1,5 @@
 import difflib
+import re
 
 from regparser.diff.text import get_opcodes, INSERT, DELETE, REPLACE, EQUAL
 from regparser.tree import struct
@@ -8,18 +9,23 @@ ADDED = 'added'
 MODIFIED = 'modified'
 DELETED = 'deleted'
 
+_whitespace = re.compile(u'\s+', re.UNICODE)    # aware of "thin" spaces, etc.
+
 
 def _local_text_changes(lhs, rhs):
     """Account for only text changes between nodes. This explicitly excludes
     children"""
-    if lhs.text != rhs.text or lhs.title != rhs.title:
+    l_text, r_text, l_title, r_title = [
+        _whitespace.sub(' ', text)
+        for text in (lhs.text, rhs.text, lhs.title, rhs.title)]
+    if l_text != r_text or l_title != r_title:
         node_changes = {"op": MODIFIED}
 
-        text_opcodes = get_opcodes(lhs.text, rhs.text)
+        text_opcodes = get_opcodes(l_text, r_text)
         if text_opcodes:
             node_changes["text"] = text_opcodes
 
-        title_opcodes = get_opcodes(lhs.title, rhs.title)
+        title_opcodes = get_opcodes(l_title, r_title)
         if title_opcodes:
             node_changes["title"] = title_opcodes
         return (lhs.label_id, node_changes)

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -131,31 +131,32 @@ def match_labels_and_changes(amendments, section_node):
     eliminate paragraphs that are just stars for positioning, for example.  """
     amended_labels = [a.label_id() for a in amendments]
 
-    amend_map = defaultdict(list)
+    amend_map = OrderedDict()
     for amend in amendments:
+        existing = amend_map.get(amend.label_id(), [])
         change = {'action': amend.action, 'amdpar_xml': amend.amdpar_xml}
         if amend.field is not None:
             change['field'] = amend.field
 
         if amend.action == 'MOVE':
             change['destination'] = amend.destination
-            amend_map[amend.label_id()].append(change)
+            amend_map[amend.label_id()] = existing + [change]
         elif amend.action == 'DELETE':
-            amend_map[amend.label_id()].append(change)
+            amend_map[amend.label_id()] = existing + [change]
         elif section_node is not None:
             node = struct.find(section_node, amend.label_id())
             if node is None:
                 candidate = find_misparsed_node(
                     section_node, amend.label, change, amended_labels)
                 if candidate:
-                    amend_map[amend.label_id()].append(candidate)
+                    amend_map[amend.label_id()] = existing + [candidate]
             else:
                 change['node'] = node
                 change['candidate'] = False
                 level2 = amend.tree_format_level2()
                 if level2 and node.is_section():
                     change['parent_label'] = level2
-                amend_map[amend.label_id()].append(change)
+                amend_map[amend.label_id()] = existing + [change]
 
     resolve_candidates(amend_map)
     return amend_map

--- a/tests/diff_tree_tests.py
+++ b/tests/diff_tree_tests.py
@@ -99,3 +99,9 @@ class DiffTreeTest(TestCase):
              'text': [('insert', len("Root"), " modified")],
              'child_ops': [('equal', 0, 1),   # 1111-a
                            ('delete', 1, 2)]})
+
+    def test_whitespace_comparison(self):
+        """We shouldn't trigger diffs for whitespace changes"""
+        lhs = FrozenNode(u"Some\t\nthing", label=['123'])
+        rhs = lhs.clone(text=u"Some\u2009 thing")   # thin-space
+        self.assertEqual(difftree.changes_between(lhs, rhs), [])


### PR DESCRIPTION
Neither change should trip integration tests (which only test a single version of each reg).

Part of a series to make Python3 results match Python2. Split out into different PRs so that comparisons with existing data are easier to spot.