### PR TITLE
Avoid raw logging usage; always name loggers

### DIFF
--- a/regparser/citations.py
+++ b/regparser/citations.py
@@ -6,6 +6,9 @@ from regparser.tree.paragraph import p_levels
 from regparser.tree.struct import Node
 
 
+logger = logging.getLogger(__name__)
+
+
 class Label(object):
     #   @TODO: subparts
     _p_markers = tuple('p{}'.format(i) for i in range(1, 10))
@@ -144,7 +147,7 @@ class Label(object):
         level = [lvl for lvl in p_levels if start in lvl and end in lvl]
         if (self.schema != other.schema or len(self_list) != len(other_list) or
                 self_list[:-1] != other_list[:-1] or not level):
-            logging.warning("Bad use of 'through': %s - %s", self, other)
+            logger.warning("Bad use of 'through': %s - %s", self, other)
         else:
             level = level[0]
             start_idx, end_idx = level.index(start), level.index(end)

--- a/regparser/commands/compare_to.py
+++ b/regparser/commands/compare_to.py
@@ -9,6 +9,9 @@ import requests_cache
 from six.moves.urllib.parse import urlparse
 
 
+logger = logging.getLogger(__name__)
+
+
 def local_and_remote_generator(api_base, paths):
     """Find all local files in `paths` and pair them with the appropriate
     remote file (prefixing with api_base). As the local files could be at any
@@ -37,7 +40,7 @@ def compare(local_path, remote_url, prompt=True):
     diff"""
     remote = path_to_json(remote_url)
     if remote is None:
-        logging.warn("Nonexistent: %s", remote_url)
+        logger.warn("Nonexistent: %s", remote_url)
         return None
 
     with open(local_path) as fp:

--- a/regparser/content.py
+++ b/regparser/content.py
@@ -7,6 +7,9 @@ import logging
 import settings
 
 
+logger = logging.getLogger(__name__)
+
+
 def _try_to_load(path, ident='module'):
     module, obj = path.rsplit('.', 1)
     try:
@@ -15,7 +18,7 @@ def _try_to_load(path, ident='module'):
         if hasattr(module, obj):
             return getattr(module, obj)
     except ImportError:
-        logging.warning("Could not load " + ident + " from " + path)
+        logger.warning("Could not load " + ident + " from " + path)
 
 
 class Macros(object):

--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -14,6 +14,9 @@ from regparser.tree.paragraph import p_levels, hash_for_paragraph
 from regparser.tree.reg_text import subjgrp_label
 
 
+logger = logging.getLogger(__name__)
+
+
 intro_text_marker = (
     (Marker("introductory") + WordBoundaries(CaselessLiteral("text"))) |
     (Marker("subject") + Marker("heading")).setParseAction(lambda _: "text")
@@ -298,7 +301,7 @@ def _through_paren(prev_lab, next_lab):
     # we can't compute A-14(a)(2) through B-14(a)(4) nor can we compute
     # A-14(a)(1) through A-14(b)(3)
     if lhs[:lhs_idx] != rhs[:rhs_idx] or prev_lab[:-1] != next_lab[:-1]:
-        logging.warning("Bad use of 'through': %s %s", prev_lab, next_lab)
+        logger.warning("Bad use of 'through': %s %s", prev_lab, next_lab)
         return []
     else:
         prefix = lhs[:lhs_idx + 1]
@@ -310,7 +313,7 @@ def _through_paren(prev_lab, next_lab):
                     return [tokens.Paragraph(prev_lab[:-1] +
                                              [prefix + level[i] + ')'])
                             for i in range(lidx + 1, ridx)]
-        logging.warning("Error with 'through': %s %s", prev_lab, next_lab)
+        logger.warning("Error with 'through': %s %s", prev_lab, next_lab)
         return []
 
 

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -13,6 +13,9 @@ from regparser.tree import struct
 from regparser.tree.paragraph import p_levels
 
 
+logger = logging.getLogger(__name__)
+
+
 def node_to_dict(node):
     """ Convert a node to a dictionary representation. We skip the
     children, turning them instead into a list of labels instead. """
@@ -96,7 +99,7 @@ def resolve_candidates(amend_map, warn=True):
                 del amend_map[label]
                 if warn:
                     mesg = 'Unable to match amendment to change for: %s'
-                    logging.warning(mesg, label)
+                    logger.warning(mesg, label)
 
 
 def find_misparsed_node(section_node, label, change, amended_labels):

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -13,6 +13,9 @@ from regparser.tree.xml_parser import interpretations, reg_text
 from regparser.utils import roman_nums
 
 
+logger = logging.getLogger(__name__)
+
+
 def get_parent_label(node):
     """ Given a node, get the label of it's parent. """
     if node.node_type == Node.SUBPART:
@@ -158,8 +161,8 @@ class RegulationTree(object):
             parent_label_id = get_parent_label(node)
             parent = find(self.tree, parent_label_id)
         if not parent:
-            logging.error("Could not find parent of %s. Misparsed amendment?",
-                          node.label_id())
+            logger.error("Could not find parent of %s. Misparsed amendment?",
+                         node.label_id())
         return parent
 
     def add_to_root(self, node):
@@ -225,7 +228,7 @@ class RegulationTree(object):
         """ Delete the node with label_id from the tree. """
         node = find(self.tree, label_id)
         if node is None:
-            logging.warning("Attempting to delete %s failed", label_id)
+            logger.warning("Attempting to delete %s failed", label_id)
         else:
             self.delete_from_parent(node)
 
@@ -309,7 +312,7 @@ class RegulationTree(object):
         """ Add an entirely new node to the regulation tree. """
         existing = find(self.tree, node.label_id())
         if existing and is_reserved_node(existing):
-            logging.warning('Replacing reserved node: %s' % node.label_id())
+            logger.warning('Replacing reserved node: %s' % node.label_id())
             return self.replace_node_and_subtree(node)
         elif existing and is_interp_placeholder(existing):
             existing.title = node.title
@@ -325,7 +328,7 @@ class RegulationTree(object):
             pass
         else:
             if existing:
-                logging.warning(
+                logger.warning(
                     'Adding a node that already exists: %s' % node.label_id())
 
             if ((node.node_type == Node.APPENDIX and len(node.label) == 2) or
@@ -340,8 +343,8 @@ class RegulationTree(object):
                 if parent is None:
                     # This is a corner case, where we're trying to add a child
                     # to a parent that should exist.
-                    logging.warning('No existing parent for: %s' %
-                                    node.label_id())
+                    logger.warning('No existing parent for: %s' %
+                                   node.label_id())
                     parent = self.create_empty_node(get_parent_label(node))
                 # Fix the case where the node with label "<PART>-Subpart" is
                 # the correct parent.
@@ -394,7 +397,7 @@ class RegulationTree(object):
         """ Move an existing node to another subpart. If the new subpart
         doesn't exist, create it. """
         if len(label.split('-')) != 2:
-            logging.error(
+            logger.error(
                 "Trying to move a non-section into a subpart: %s -> %s",
                 label, subpart_label)
             return
@@ -486,8 +489,8 @@ def one_change(reg, label, change):
         node = dict_to_node(change['node'])
         reg.insert_in_order(node)
     else:
-        logging.warning("Unsure how to compile with this action: %s @ %s",
-                        change['action'], label)
+        logger.warning("Unsure how to compile with this action: %s @ %s",
+                       change['action'], label)
 
 
 def _needs_delay(reg, change):
@@ -532,6 +535,6 @@ def compile_regulation(previous_tree, notice_changes):
 
     # Force any remaining changes -- generally means something went wrong
     for label, change in next_pass:
-        logging.warning('Conflicting Change: %s:%s', label, change['action'])
+        logger.warning('Conflicting Change: %s:%s', label, change['action'])
         one_change(reg, label, change)
     return reg.tree

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -136,7 +136,7 @@ class NoticeXML(XMLWrapper):
             # The FR Notice XML doesn't tend to have all the metadata we need
             # contained within it, so don't try to parse that, just log an
             # error.
-            logging.warn("Preprocessing notice: no agency metadata.")
+            logger.warn("Preprocessing notice: no agency metadata.")
             return {}
 
         # We need turn turn the references to parent_ids into a tree of dicts

--- a/regparser/tree/interpretation.py
+++ b/regparser/tree/interpretation.py
@@ -9,6 +9,7 @@ from regparser.tree.paragraph import ParagraphParser
 from regparser.tree.struct import Node, treeify
 
 
+logger = logging.getLogger(__name__)
 #   Can only be preceded by white space or a start of line
 interpParser = ParagraphParser(r"(?<![^\s])%s\.", Node.INTERP)
 
@@ -97,5 +98,5 @@ def text_to_labels(text, initial_label, warn=True, force_start=False):
                 list(initial_pars[0]) +
                 [Node.INTERP_MARK]]
     elif warn:
-        logging.warning("Couldn't turn into label: " + text)
+        logger.warning("Couldn't turn into label: " + text)
     return []

--- a/regparser/tree/xml_parser/interpretations.py
+++ b/regparser/tree/xml_parser/interpretations.py
@@ -13,6 +13,7 @@ from regparser.tree.struct import Node, treeify
 from regparser.tree.xml_parser import tree_utils
 
 
+logger = logging.getLogger(__name__)
 _marker_regex = re.compile(
     r'^\s*(' +                 # line start
     '([0-9]+)' +               # digits
@@ -117,8 +118,8 @@ def process_inner_children(inner_stack, xml_node):
         if xml_node.tag == 'STARS':
             nodes.append(Node(label=[mtypes.STARS_TAG]))
         elif not first_marker and nodes:
-            logging.warning("Couldn't determine interp marker. Appending to "
-                            "previous paragraph: %s", node_text)
+            logger.warning("Couldn't determine interp marker. Appending to "
+                           "previous paragraph: %s", node_text)
             previous = nodes[-1]
             previous.text += "\n\n" + node_text
             if hasattr(previous, 'tagged_text'):

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -128,15 +128,15 @@ class ParagraphProcessor(object):
             depths = derive_depths(markers, constraints)
 
             if not depths:
-                logging.warning("Could not derive paragraph depths."
-                                " Retrying with relaxed constraints.")
+                logger.warning("Could not derive paragraph depths."
+                               " Retrying with relaxed constraints.")
                 deemphasized_markers = [deemphasize(m) for m in markers]
                 constraints = self.relaxed_constraints()
                 depths = derive_depths(deemphasized_markers, constraints)
 
             if not depths:
                 fails_at = debug_idx(markers, constraints)
-                logging.error(
+                logger.error(
                     "Could not determine paragraph depths (<%s /> %s):\n"
                     "%s\n"
                     "?? %s\n"

--- a/tests/commands_compare_to_tests.py
+++ b/tests/commands_compare_to_tests.py
@@ -68,9 +68,9 @@ class CommandsCompareToTests(HttpMixin, TestCase):
     def test_compare_404(self):
         """If the remote file doesn't exist, we should be notified"""
         self.expect_json_http(status=404)
-        with patch('regparser.commands.compare_to.logging') as logging:
+        with patch('regparser.commands.compare_to.logger') as logger:
             self.run_compare('local_file', 'http://example.com/remote')
-        self.assertEqual(logging.warn.call_args[0],
+        self.assertEqual(logger.warn.call_args[0],
                          ('Nonexistent: %s', 'http://example.com/remote'))
 
     def test_compare_no_diff(self):


### PR DESCRIPTION
As we're moving to an asynchronous model, we'll want to be able to target
relevant logs. We can only target these logs if they have a _name_