### PR TITLE
First draft at an async workflow

### DIFF
--- a/async_eregs.py
+++ b/async_eregs.py
@@ -1,0 +1,72 @@
+"""
+Asynchronous `eregs` commands. To run,
+    1. install `rq`
+    2. start redis. For example, with docker:
+        docker run -p 6379 -d redis
+    3. start a worker process
+        rq worker
+        # use the --url form if needed:
+        # rq worker --url redis://hostname:port/db
+    4. run an asynchronous command
+        python async_eregs.py pipeline 27 479 async_output_dir
+        # use --host, --port, --db if needed
+        # python async_eregs.py --host example.com pipeline ...
+    5. check the status of your jobs:
+        python async_eregs.py   # no parameters other than host, port, db
+"""
+
+import click
+from rq import Queue, registry
+from rq.queue import FailedQueue
+from redis import StrictRedis
+
+from regparser.tasks import run_eregs_command
+
+
+def _print(job):
+    log_length = len(job.meta.get('logs', ''))
+    click.echo("\t({}){}".format(log_length, job))
+
+
+def show_stats(conn):
+    """Print some metrics to stdout"""
+    queue = Queue(connection=conn)
+    click.echo("Queued:")
+    for job in queue.jobs:
+        _print(job)
+
+    click.echo("Started:")
+    for job_id in registry.StartedJobRegistry(connection=conn).get_job_ids():
+        _print(queue.fetch_job(job_id))
+
+    click.echo("Finished:")
+    for job_id in registry.FinishedJobRegistry(connection=conn).get_job_ids():
+        _print(queue.fetch_job(job_id))
+
+    click.echo("Failed:")
+    for job in FailedQueue(connection=conn).jobs:
+        _print(job)
+
+
+@click.command(context_settings=dict(ignore_unknown_options=True))
+@click.option('--host', default='localhost', help='Redis host')
+@click.option('--port', default=6379, help='Redis port')
+@click.option('--db', default=0, help='Redis db')
+@click.argument('eregs_args', nargs=-1, type=click.UNPROCESSED)
+def main(host, port, db, eregs_args):
+    """Run an eregs command asynchronously."""
+    eregs_args = list(eregs_args)
+    conn = StrictRedis(host=host, port=port, db=db)
+    if not eregs_args:
+        show_stats(conn)
+    else:
+        queue = Queue(connection=conn)
+        # Can't directly use the above context as it doesn't pickle well
+        queue.enqueue(run_eregs_command, eregs_args, host, port, db,
+                      # Run for at most half an hour, don't delete successes
+                      timeout=60*30, result_ttl=-1)
+        click.echo("OK")
+
+
+if __name__ == '__main__':
+    main()

--- a/eregs.py
+++ b/eregs.py
@@ -60,8 +60,8 @@ def run_or_resolve(cmd, prev_dependency=None):
         raise
 
 
-def main(prev_dependency=None):
-    run_or_resolve(cli, prev_dependency=prev_dependency)
+def main():
+    run_or_resolve(cli)
 
 
 if __name__ == '__main__':

--- a/regparser/tasks.py
+++ b/regparser/tasks.py
@@ -1,0 +1,33 @@
+import logging
+
+from redis import StrictRedis
+from rq import get_current_job
+from six import StringIO
+
+import eregs
+
+
+def run_eregs_command(eregs_args, host, port, db):
+    """Run `eregs *eregs_args`, capturing all of the logs and storing them in
+    Redis"""
+    log = StringIO()
+    logger = logging.getLogger('regparser')
+    log_handler = logging.StreamHandler(log)
+
+    logger.propagate = False
+    logger.addHandler(log_handler)
+
+    try:
+        eregs.run_or_resolve(lambda: eregs.cli.invoke(
+            # Must recreate the context each time so that the arg
+            # list can be destroyed again
+            eregs.cli.make_context('eregs', args=list(eregs_args))))
+    finally:
+        log_handler.flush()
+        # Recreating the connection due to a bug in rq:
+        # https://github.com/nvie/rq/issues/479
+        conn = StrictRedis(host=host, port=port, db=db)
+        job = get_current_job(conn)
+        job.meta['logs'] = log.getvalue()
+        job.save()
+        logger.removeHandler(log_handler)


### PR DESCRIPTION
Instructions for running are in the docs. Decided not to include the rq
requirement just yet -- I think it'll be an "optional" when we do.

Index is still based on the file system.

Used `rq` instead of `celery` for ease of use. Doing things like making exceptions failures, listing which processes failed, storing captured logs, etc. all work with minimal fan fare on `rq`.

For eregs/notice-and-comment#379