### PR TITLE
Switch to py.test

### DIFF
--- a/docs/dev_tasks.rst
+++ b/docs/dev_tasks.rst
@@ -33,18 +33,18 @@ the testing requirements:
 
   pip install -r requirements_test.txt
 
-Then, run nose on all of the available unit tests:
+Then, run py.test on all of the available unit tests:
 
 .. code-block:: bash
 
-  nosetests
+  py.test
 
 If you'd like a report of test coverage, use the
-`nose-cov <https://pypi.python.org/pypi/nose-cov>`_ plugin:
+`pytest-cov <https://pypi.python.org/pypi/pytest-cov>`_ plugin:
 
 .. code-block:: bash
 
-  nosetests --with-cov --cov-report term-missing --cov regparser
+  py.test --cov-report term-missing --cov regparser
 
 Note also that this library is continuously tested via Travis. Pull requests
 should rarely be merged unless Travis gives the green light.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -29,21 +29,5 @@ Features
 Requirements
 ------------
 
-* Python (2.7)
-* lxml (3.2.0) - Used to parse out information XML from the federal register
-* pyparsing (1.5.7) - Used to do generic parsing on the plain text
-* inflection (0.1.2) - Helps determine pluralization (for terms layer)
-* requests (1.2.3) - Client library for writing output to an API
-* requests_cache (0.4.4) - *Optional* - Library for caching request results
-  (speeds up rebuilding regulations)
-* GitPython (0.3.2.RC1) - Allows the regulation to be written as a git repo
-* python-constraint (1.2) - Used to determine paragraph depth
-
-If running tests:
-
-* nose (1.2.1) - A pluggable test runner
-* mock (1.0.1) - Makes constructing mock objects/functions easy
-* coverage (3.6) - Reports on test coverage
-* cov-core (1.7) - Needed by coverage
-* nose-cov (1.6) - Connects nose to coverage
-
+Python 2.7, 3.3, 3.4, 3.5. See ``requirements.txt`` and similar for specific
+library versions.

--- a/regparser/commands/full_tests.py
+++ b/regparser/commands/full_tests.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 import requests_cache
 from stevedore import extension
@@ -26,14 +28,15 @@ def get_stevedore_module_names(namespace):
 
 @click.command()
 def full_tests():
-    import nose
+    import pytest
 
-    mymods = ["", "tests"]  # nose essentially ignores the first arg to argv.
+    mymods = ["tests"]
     mymods.extend(get_stevedore_module_names("eregs_ns.parser.test_suite"))
 
     requests_cache.uninstall_cache()
 
-    nose.run(argv=mymods)
+    errno = pytest.main(['--pyargs'] + mymods)
+    sys.exit(errno)
 
 if __name__ == '__main__':
     full_tests()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,5 @@ httpretty==0.8.14
 mock==2.0.0
 nose==1.3.7
 nose-cov==1.6
+pytest==2.9.2
+pytest-cov==2.2.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,5 @@ pep8==1.7.0
 flake8==2.5.4
 httpretty==0.8.14
 mock==2.0.0
-nose==1.3.7
-nose-cov==1.6
 pytest==2.9.2
 pytest-cov==2.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[pytest]
+python_files=test_*.py *_test.py *_tests.py
+
 [flake8]
 exclude = docs/*,*settings.py

--- a/test-travis.sh
+++ b/test-travis.sh
@@ -2,7 +2,7 @@ set -e
 set -x
 
 if [[ $INTEGRATION_TARGET = '' ]]; then
-  nosetests --with-cov --cov-report term-missing --cov regparser
+  py.test --cov-report term-missing --cov regparser
   flake8 .
 else
   eregs clear


### PR DESCRIPTION
py.test seems to be the way the winds are blowing, and it's simple enough to swap out. This PR doesn't modify any existing tests, though we may want to simplify them using raw `assert`s, etc. in the future.

Resolves #269