### PR TITLE
Add EPA to integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.5"
 cache: pip
 install:
-  - pip install -U pip wheel
   - pip install -r requirements.txt
   - pip install -r requirements_test.txt
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - INTEGRATION_TARGET=
     - INTEGRATION_TARGET=fec
     - INTEGRATION_TARGET=atf
+    - INTEGRATION_TARGET=epa
 script:
   - ./test-travis.sh
 after_success:

--- a/integration_test.py
+++ b/integration_test.py
@@ -38,6 +38,13 @@ targets = {
             'atf_regparser': '-e git+https://github.com/18F/atf-eregs.git#egg=atf_regparser&subdirectory=eregs_extensions',  # noqa
         },
     },
+    'epa': {
+        'title': 40,
+        'parts': [262, 263, 264, 265, 271],
+        'requirements': {
+            'epa_regparser': '-e git+https://github.com/18F/epa-notice.git#egg=epa_regparser&subdirectory=eregs_extensions',  # noqa
+        },
+    },
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pip==8.1.2
 boto3==1.3.1
 cached-property==1.3.0
 click==6.6


### PR DESCRIPTION
Also pins pip version. We expect Travis to fail on the EPA tests (as they don't exist yet), but everything else should stay the same.