### PR TITLE
Add tagged_text to table nodes

### DIFF
--- a/regparser/layer/formatting.py
+++ b/regparser/layer/formatting.py
@@ -253,6 +253,7 @@ def node_to_table_xml_els(node):
     if node.source_xml is not None:
         root_xml_el = node.source_xml
     else:
+        # Wrap tagged_text in a placeholder tag as it might be an XML fragment
         root_xml_el = etree.fromstring(u'<ROOT>{}</ROOT>'.format(
             getattr(node, 'tagged_text', '')))
 

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -219,7 +219,7 @@ class TableMatcher(BaseMatcher):
     def derive_nodes(self, xml, processor=None):
         node = Node(table_xml_to_plaintext(xml), label=[mtypes.MARKERLESS],
                     source_xml=xml)
-        node.tagged_text = etree.tostring(xml).strip()
+        node.tagged_text = etree.tounicode(xml).strip()
         return [node]
 
 

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -217,8 +217,10 @@ class TableMatcher(BaseMatcher):
         return xml.tag == 'GPOTABLE'
 
     def derive_nodes(self, xml, processor=None):
-        return [Node(table_xml_to_plaintext(xml), label=[mtypes.MARKERLESS],
-                     source_xml=xml)]
+        node = Node(table_xml_to_plaintext(xml), label=[mtypes.MARKERLESS],
+                     source_xml=xml)
+        node.tagged_text = etree.tostring(xml).strip()
+        return [node]
 
 
 class HeaderMatcher(BaseMatcher):

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -218,7 +218,7 @@ class TableMatcher(BaseMatcher):
 
     def derive_nodes(self, xml, processor=None):
         node = Node(table_xml_to_plaintext(xml), label=[mtypes.MARKERLESS],
-                     source_xml=xml)
+                    source_xml=xml)
         node.tagged_text = etree.tostring(xml).strip()
         return [node]
 

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -390,6 +390,20 @@ class LayerFormattingTests(TestCase):
             ])
 
 
+def test_node_to_table_xml_els():
+    """We should be able to find a GPOTABLE in multiple places"""
+    xml_str = '<GPOTABLE unique="id">Content</GPOTABLE>'
+    nested_str = '<P>Stuff <NESTED>{}</NESTED></P>'.format(xml_str)
+    node1 = Node(source_xml=etree.fromstring(xml_str))
+    node2 = Node(source_xml=etree.fromstring(nested_str))
+    node3 = Node(tagged_text=xml_str)
+    node4 = Node(tagged_text=nested_str)
+    for node in (node1, node2, node3, node4):
+        result = formatting.node_to_table_xml_els(node)
+        assert len(result) == 1
+        assert result[0].attrib['unique'] == 'id'
+
+
 class FencedTests(TestCase):
     def test_process(self):
         text = "Content content\n```abc def\nLine 1\nLine 2\n```"

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -260,6 +260,7 @@ class RegTextTest(TestCase):
         table_node = extract_node.children[0]
         self.assertEqual('regtext', table_node.node_type)
         self.assertEqual('GPOTABLE', table_node.source_xml.tag)
+        self.assertTrue(table_node.tagged_text.startswith('<GPOTABLE'))
 
     def test_build_from_section_extract_with_table_and_headers(self):
         """Account for regtext with a header and a table in an extract"""


### PR DESCRIPTION
We've got an ugly mix of relying on `source_xml` and `tagged_text` for
different things throughout this code base. Right now, the formatting layer
assumes that table information will be present in `source_xml`, yet the
notice-compiling code is only aware of `tagged_text`.

This updates the table-related code to make use of the `tagged_text` field; the other way (modifying notice-compiling code) would be much more difficult. Part of 18F/eregs-platform#19