### PR TITLE
Switch hashing from MD5 to SHA256.

### DIFF
--- a/regparser/web/jobs/models.py
+++ b/regparser/web/jobs/models.py
@@ -39,7 +39,7 @@ class PipelineJob(ParsingJob):
 
 class ProposalPipelineJob(ParsingJob):
 
-    file_hexhash = models.CharField(max_length=32)
+    file_hexhash = models.CharField(max_length=64)
     only_latest = models.BooleanField(default=True)
 
 
@@ -48,5 +48,5 @@ class RegulationFile(models.Model):
     contents = models.BinaryField()
     file = models.FileField(null=True)
     filename = models.CharField(default=None, max_length=512, null=True)
-    hexhash = models.CharField(default=None, max_length=32, null=True)
+    hexhash = models.CharField(default=None, max_length=64, null=True)
     url = models.URLField(blank=True, max_length=2000)

--- a/regparser/web/jobs/serializers.py
+++ b/regparser/web/jobs/serializers.py
@@ -58,7 +58,7 @@ class ProposalPipelineJobSerializer(ParsingJobSerializer):
         )
 
     # Fields we don't want user input for are listed below.
-    file_hexhash = serializers.CharField(max_length=32)
+    file_hexhash = serializers.CharField(max_length=64)
 
 
 class FileUploadSerializer(serializers.ModelSerializer):

--- a/regparser/web/jobs/urls.py
+++ b/regparser/web/jobs/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
         views.ProposalPipelineJobViewList.as_view()),
     url(r'^jobs/notices(/)(?P<job_id>[-a-z0-9]+)(/)$',
         views.ProposalPipelineJobViewInstance.as_view()),
-    url(r'^jobs/files/(?P<hexhash>[a-z0-9]{32})(/)$',
+    url(r'^jobs/files/(?P<hexhash>[a-z0-9]{64})(/)$',
         views.FileUploadViewInstance.as_view()),
     url(r'^jobs/files(/)$',
         views.FileUploadView.as_view()),

--- a/regparser/web/jobs/views.py
+++ b/regparser/web/jobs/views.py
@@ -317,8 +317,8 @@ class FileUploadView(mixins.ListModelMixin, mixins.CreateModelMixin,
             contents = b"".join(chunk for chunk in uploaded_file.chunks())
         else:
             contents = uploaded_file.read()
-        md = hashlib.md5(contents)
-        hexhash = md.hexdigest()
+        sha = hashlib.sha256(contents)
+        hexhash = sha.hexdigest()
         filename = uploaded_file.name
         url = file_url(hexhash)
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,4 +1,4 @@
-from hashlib import md5
+from hashlib import sha256
 from mock import patch, Mock
 from os import path as ospath
 from six.moves.urllib.parse import urlparse
@@ -143,7 +143,7 @@ class RegulationFileTestCase(APITestCase):
 
     def get_hashed_contents(self):
         if self.hashed_contents is None:
-            self.hashed_contents = md5(self.file_contents.encode(
+            self.hashed_contents = sha256(self.file_contents.encode(
                 "utf-8")).hexdigest()
         return self.hashed_contents
 


### PR DESCRIPTION
“I don't often hash /
But when I hash files, I use /
SHA256.”