### PR TITLE
Updates to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pip==8.1.2
-boto3==1.3.1
 cached-property==1.3.0
 click==6.6
 coloredlogs==5.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+boto3==1.3.1
 cov-core==1.15.0
 coverage==4.1
 flake8==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="regparser",
-    version="2.0.0",
+    version="4.0.0",
     packages=find_packages(),
     classifiers=[
         'License :: Public Domain',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ setup(
         "cached-property",
         "click",
         "coloredLogs",
+        "Django==1.9.*",
+        "dj-database-url",
+        "django-click",
+        "django_rq",
+        "djangorestframework",
         "GitPython",
         "inflection",
         "ipdb",
@@ -21,7 +26,9 @@ setup(
         "pyparsing",
         "python-constraint",
         "requests",
-        "requests-cache"
+        "requests-cache",
+        "six",
+        "stevedore"
     ],
     entry_points={"console_scripts": ["eregs=eregs:main"]}
 )


### PR DESCRIPTION
Set a new version number and update the requirements. This should make it easier to pin this version in downstream applications (e.g. in ATF's docs).