### PR TITLE
Account for E tags in subpart/subject group titles

### DIFF
--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -120,20 +120,15 @@ def build_tree(reg_xml):
     return tree
 
 
-def get_subpart_title(subpart_xml):
+def get_subpart_group_title(subpart_xml):
+    """Derive the title of a subpart or subject group"""
     hds = subpart_xml.xpath('./RESERVED|./HD')
     if hds:
-        return [hd.text for hd in hds][0]
-
-
-def get_subjgrp_title(subjgrp_xml):
-    hds = subjgrp_xml.xpath('./RESERVED|./HD')
-    if hds:
-        return [hd.text for hd in hds][0]
+        return tree_utils.get_node_text(hds[0])
 
 
 def build_subpart(reg_part, subpart_xml):
-    subpart_title = get_subpart_title(subpart_xml)
+    subpart_title = get_subpart_group_title(subpart_xml)
     subpart = reg_text.build_subpart(subpart_title, reg_part)
 
     sections = []
@@ -148,7 +143,7 @@ def build_subpart(reg_part, subpart_xml):
 def build_subjgrp(reg_part, subjgrp_xml, letter_list):
     # This handles subjgrps that have been pulled out and injected into the
     # same level as subparts.
-    subjgrp_title = get_subjgrp_title(subjgrp_xml)
+    subjgrp_title = get_subpart_group_title(subjgrp_xml)
     letter_list, subjgrp = reg_text.build_subjgrp(subjgrp_title, reg_part,
                                                   letter_list)
 

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -497,18 +497,6 @@ class RegTextTest(TestCase):
         part = reg_text.get_reg_part(ctx.xml)
         self.assertEqual(part, '204')
 
-    def test_get_subpart_title(self):
-        with XMLBuilder("SUBPART") as ctx:
-            ctx.HD(u"Subpart A—First subpart")
-        subpart_title = reg_text.get_subpart_title(ctx.xml)
-        self.assertEqual(subpart_title, u'Subpart A—First subpart')
-
-    def test_get_subpart_title_reserved(self):
-        with XMLBuilder("SUBPART") as ctx:
-            ctx.RESERVED("Subpart J [Reserved]")
-        subpart_title = reg_text.get_subpart_title(ctx.xml)
-        self.assertEqual(subpart_title, u'Subpart J [Reserved]')
-
     def test_build_subpart(self):
         with XMLBuilder("SUBPART") as ctx:
             ctx.HD(u"Subpart A—First subpart")
@@ -767,3 +755,25 @@ class RegtextParagraphProcessorTests(TestCase):
         self.assertEqual(code['x']['1']['A']['i'].text, '(i)')
         self.assertEqual(code['x']['1']['A']['i']['I'].text,
                          '(I) Even more nested')
+
+
+def test_get_subpart_group_title():
+    with XMLBuilder("SUBPART") as ctx:
+        ctx.HD(u"Subpart A—First subpart")
+    subpart_title = reg_text.get_subpart_group_title(ctx.xml)
+    assert subpart_title == u'Subpart A—First subpart'
+
+
+def test_get_subpart_group_title_reserved():
+    with XMLBuilder("SUBPART") as ctx:
+        ctx.RESERVED("Subpart J [Reserved]")
+    subpart_title = reg_text.get_subpart_group_title(ctx.xml)
+    assert subpart_title == u'Subpart J [Reserved]'
+
+
+def test_get_subpart_group_title_em():
+    with XMLBuilder("SUBPART") as ctx:
+        ctx.child_from_string(
+            u'<HD SOURCE="HED">Subpart B—<E T="0714">Partes</E> Review</HD>')
+    subpart_title = reg_text.get_subpart_group_title(ctx.xml)
+    assert subpart_title == u'Subpart B—Partes Review'


### PR DESCRIPTION
Also combines the get_subpart_title and get_subjgrp_title functions, which
were identical

Should resolve #321 
