### PR TITLE
Replace duplicated logic with declarative style

### DIFF
--- a/regparser/notice/preamble.py
+++ b/regparser/notice/preamble.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from copy import deepcopy
 from itertools import takewhile
 import re
@@ -49,14 +50,9 @@ class PreambleProcessor(ParagraphProcessor):
                 TableMatcher()
                 ]
 
-    def select_depth(self, depths):
-        """Override ParagraphProcessor to add different weights"""
-        depths = heuristics.prefer_diff_types_diff_levels(depths, 0.2)
-        depths = heuristics.prefer_multiple_children(depths, 0.4)
-        depths = heuristics.prefer_shallow_depths(depths, 0.8)
-        depths = heuristics.prefer_no_markerless_sandwich(depths, 0.2)
-        depths = sorted(depths, key=lambda d: d.weight, reverse=True)
-        return depths[0]
+    DEPTH_HEURISTICS = OrderedDict(ParagraphProcessor.DEPTH_HEURISTICS)
+    DEPTH_HEURISTICS[heuristics.prefer_diff_types_diff_levels] = 0.2
+    DEPTH_HEURISTICS[heuristics.prefer_shallow_depths] = 0.8
 
 
 def transform_xml(elements, title, depth):

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -74,12 +74,7 @@ class NoticeXML(XMLWrapper):
     def _set_date_attr(self, date_type, value):
         """Modify the XML tree so that it contains meta data for a date
         field. Accepts both strings and dates"""
-        dates_tag = self.xpath('//DATES')
-        if dates_tag:
-            dates_tag = dates_tag[0]
-        else:   # Tag wasn't present; create it
-            dates_tag = etree.Element("DATES")
-            self.xml.insert(0, dates_tag)
+        dates_tag = self._find_or_create('DATES')
         if isinstance(value, date):
             value = value.isoformat()
         if value is None:
@@ -251,14 +246,9 @@ class NoticeXML(XMLWrapper):
 
         :arg list value: RINs, which should be strings.
         """
-        rins_el = self.xpath('//EREGS_RINS')
-        if rins_el:
-            rins_el = rins_el[0]
-        else:   # Tag wasn't present; create it
-            rins_el = etree.Element("EREGS_RINS")
+        rins_el = self._find_or_create('EREGS_RINS')
         for rin in value:
             etree.SubElement(rins_el, "EREGS_RIN", rin=rin)
-        self.xml.insert(0, rins_el)
 
     @property
     def docket_ids(self):
@@ -278,14 +268,9 @@ class NoticeXML(XMLWrapper):
 
         :arg list value: docket_ids, which should be strings.
         """
-        dids_el = self.xpath('//EREGS_DOCKET_IDS')
-        if dids_el:
-            dids_el = dids_el[0]
-        else:   # Tag wasn't present; create it
-            dids_el = etree.Element("EREGS_DOCKET_IDS")
+        dids_el = self._find_or_create('EREGS_DOCKET_IDS')
         for docket_id in value:
             etree.SubElement(dids_el, "EREGS_DOCKET_ID", docket_id=docket_id)
-        self.xml.insert(0, dids_el)
 
     @property
     def cfr_refs(self):
@@ -408,11 +393,7 @@ class NoticeXML(XMLWrapper):
 
         :arg list value: list of regs_gov.RegsGovDocs
         """
-        container = self.xpath('//EREGS_SUPPORTING_DOCS')
-        if container:
-            container = container[0]
-        else:   # Tag wasn't present; create it
-            container = etree.SubElement(self.xml, 'EREGS_SUPPORTING_DOCS')
+        container = self._find_or_create('EREGS_SUPPORTING_DOCS')
         for doc in value:
             etree.SubElement(container, 'EREGS_SUPPORTING_DOC',
                              **doc._asdict())

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -171,23 +171,20 @@ class NoticeXML(XMLWrapper):
             result = notice_cfr_p.parseString(cfr_elm.text)
             yield TitlePartsRef(result.cfr_title, list(result.cfr_parts))
 
-    def derive_closing_date(self):
+    def _derive_date_type(self, date_type):
         """Attempt to parse comment closing date from DATES tags. Returns a
         datetime.date and sets the corresponding field"""
         dates = fetch_dates(self.xml) or {}
-        if 'comments' in dates:
+        if date_type in dates:
             comments = datetime.strptime(
-                dates['comments'][0], "%Y-%m-%d").date()
+                dates[date_type][0], "%Y-%m-%d").date()
             return comments
 
+    def derive_closing_date(self):
+        return self._derive_date_type('comments')
+
     def derive_effective_date(self):
-        """Attempt to parse effective date from DATES tags. Returns a
-        datetime.date and sets the corresponding field"""
-        dates = fetch_dates(self.xml) or {}
-        if 'effective' in dates:
-            effective = datetime.strptime(
-                dates['effective'][0], "%Y-%m-%d").date()
-            return effective
+        return self._derive_date_type('effective')
 
     def _get_date_attr(self, date_type):
         """Pulls out the date set in `set_date_attr`, as a datetime.date. If

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -1,4 +1,5 @@
 import abc
+from collections import OrderedDict
 import logging
 
 from lxml import etree
@@ -26,6 +27,13 @@ class ParagraphProcessor(object):
     # Subclasses should override the following interface
     MATCHERS = []
 
+    # Subclasses may choose to change the depth-deriving heuristics or weights
+    DEPTH_HEURISTICS = OrderedDict()
+    DEPTH_HEURISTICS[heuristics.prefer_diff_types_diff_levels] = 0.8
+    DEPTH_HEURISTICS[heuristics.prefer_multiple_children] = 0.4
+    DEPTH_HEURISTICS[heuristics.prefer_shallow_depths] = 0.2
+    DEPTH_HEURISTICS[heuristics.prefer_no_markerless_sandwich] = 0.2
+
     def parse_nodes(self, xml):
         """Derive a flat list of nodes from this xml chunk. This does nothing
         to determine node depth"""
@@ -49,10 +57,8 @@ class ParagraphProcessor(object):
     def select_depth(self, depths):
         """There might be multiple solutions to our depth processing problem.
         Use heuristics to select one."""
-        depths = heuristics.prefer_diff_types_diff_levels(depths, 0.8)
-        depths = heuristics.prefer_multiple_children(depths, 0.4)
-        depths = heuristics.prefer_shallow_depths(depths, 0.2)
-        depths = heuristics.prefer_no_markerless_sandwich(depths, 0.2)
+        for fn, weight in self.DEPTH_HEURISTICS.items():
+            depths = fn(depths, weight)
         depths = sorted(depths, key=lambda d: d.weight, reverse=True)
         return depths[0]
 

--- a/regparser/tree/xml_parser/xml_wrapper.py
+++ b/regparser/tree/xml_parser/xml_wrapper.py
@@ -45,3 +45,12 @@ class XMLWrapper(object):
 
     def xml_str(self):
         return etree.tounicode(self.xml, pretty_print=True)
+
+    def _find_or_create(self, tag):
+        """Look for the first matching tag present in the document. If it's
+        not present, create it by inserting it into the root"""
+        matches = self.xpath('//' + tag)
+        if matches:
+            return matches[0]
+        else:
+            return etree.SubElement(self.xml, tag)

--- a/tests/layer_external_citations_tests.py
+++ b/tests/layer_external_citations_tests.py
@@ -1,5 +1,4 @@
-# vim: set encoding=utf-8
-from unittest import TestCase
+# -*- coding: utf-8 -*-
 
 from mock import patch
 
@@ -17,113 +16,145 @@ def get_citation(citations, text):
     return None
 
 
-class ParseTest(TestCase):
-    def test_public_law(self):
-        """
-            Ensure that we successfully parse Public Law citations that look
-            like the following: Public Law 111-203
-        """
-        node = Node("Public Law 111-203", label=['1005', '2'])
+def test_public_law():
+    """
+        Ensure that we successfully parse Public Law citations that look
+        like the following: Public Law 111-203
+    """
+    node = Node("Public Law 111-203", label=['1005', '2'])
+    citations = ExternalCitationParser(None).process(node)
+    assert len(citations) == 1
+    cit = citations[0]
+    assert cit['text'] == node.text
+    assert cit['citation_type'] == 'PUBLIC_LAW'
+    assert cit['components'] == {'congress': '111', 'lawnum': '203'}
+    assert cit['locations'] == [0]
+    url = cit.get('url', '')
+    assert 'congress=111' in url
+    assert 'lawnum=203' in url
+    assert 'collection=plaw' in url
+    assert 'lawtype=public' in url
+
+
+def test_statues_at_large():
+    """
+        Ensure that we successfully parse Statues at Large citations that
+        look like the following: 122 Stat. 1375
+    """
+    node = Node('122 Stat. 1375', label=['1003', '5'])
+    citations = ExternalCitationParser(None).process(node)
+    assert len(citations) == 1
+    cit = citations[0]
+    assert cit['text'] == node.text
+    assert cit['citation_type'] == 'STATUTES_AT_LARGE'
+    assert cit['components'] == {'volume': '122', 'page': '1375'}
+    assert cit['locations'] == [0]
+    url = cit.get('url', '')
+    assert 'volume=122' in url
+    assert 'page=1375' in url
+    assert 'collection=statute' in url
+
+
+def test_cfr():
+    """Ensure that we successfully parse CFR references."""
+    node = Node("Ref 1: 12 CFR part 1026. Ref 2: 12 CFR 1026.13.",
+                label=['1003'])
+    citations = ExternalCitationParser(None).process(node)
+
+    cit = get_citation(citations, '12 CFR part 1026')
+    assert cit['citation_type'] == 'CFR'
+    assert cit['components'] == {'cfr_title': '12', 'part': '1026'}
+    assert cit['locations'] == [0]
+    url = cit.get('url', '')
+    assert 'titlenum=12' in url
+    assert 'partnum=1026' in url
+    assert 'section' not in url
+    assert 'collection=cfr' in url
+
+    cit = get_citation(citations, '12 CFR 1026.13')
+    assert cit['citation_type'] == 'CFR'
+    assert cit['components'] == {
+        'cfr_title': '12', 'part': '1026', 'section': '13'
+    }
+    assert cit['locations'] == [0]
+    url = cit.get('url', '')
+    assert 'titlenum=12' in url
+    assert 'partnum=1026' in url
+    assert 'section=13' in url
+    assert 'collection=cfr' in url
+
+
+def test_cfr_multiple():
+    """Ensure that we successfully parse multiple CFR references."""
+    node = Node("Some text 26 CFR 601.121 through 601.125 some more text",
+                label=['1003'])
+    citations = ExternalCitationParser(None).process(node)
+
+    cit = get_citation(citations, '26 CFR 601.121')
+    assert cit['citation_type'] == 'CFR'
+    assert cit['components'] == {
+        'cfr_title': '26', 'part': '601', 'section': '121'
+    }
+    assert cit['locations'] == [0]
+    url = cit.get('url', '')
+    assert 'titlenum=26' in url
+    assert 'partnum=601' in url
+    assert 'section=121' in url
+    assert 'collection=cfr' in url
+
+    cit = get_citation(citations, '601.125')
+    assert cit['citation_type'] == 'CFR'
+    assert cit['components'] == {
+        'cfr_title': '26', 'part': '601', 'section': '125'
+    }
+    assert cit['locations'] == [0]
+    url = cit.get('url', '')
+    assert 'titlenum=26' in url
+    assert 'partnum=601' in url
+    assert 'section=125' in url
+    assert 'collection=cfr' in url
+
+
+def test_drop_self_referential_cfr():
+    """
+        Ensure that CFR references that refer to the reg being parsed are
+        not marked as external citations.
+    """
+    node = Node("11 CFR 110.14", label=['110', '1'])
+    citations = ExternalCitationParser(None).process(node)
+    assert citations is None
+
+
+def test_custom():
+    """Ensure that custom citations are found. Also verify multiple
+    matches are found and word boundaries respected"""
+    node = Node("This has MAGIC text. Not magic, or MAGICAL, but MAGIC")
+    to_patch = ('regparser.layer.external_types.settings.'
+                'CUSTOM_CITATIONS')
+
+    with patch.dict(to_patch, {'MAGIC': 'http://example.com/magic'}):
         citations = ExternalCitationParser(None).process(node)
-        self.assertEqual(len(citations), 1)
-        self.assertEqual(citations[0]['text'], node.text)
-        self.assertEqual(citations[0]['citation_type'], 'PUBLIC_LAW')
-        self.assertEqual(citations[0]['components'],
-                         {'congress': '111', 'lawnum': '203'})
-        self.assertEqual(citations[0]['locations'], [0])
-        self.assertTrue('url' in citations[0])
 
-    def test_statues_at_large(self):
-        """
-            Ensure that we successfully parse Statues at Large citations that
-            look like the following: 122 Stat. 1375
-        """
-        node = Node('122 Stat. 1375', label=['1003', '5'])
-        citations = ExternalCitationParser(None).process(node)
-        self.assertEqual(len(citations), 1)
-        self.assertEqual(citations[0]['text'], node.text)
-        self.assertEqual(citations[0]['citation_type'], 'STATUTES_AT_LARGE')
-        self.assertEqual(citations[0]['components'],
-                         {'volume': '122', 'page': '1375'})
-        self.assertEqual(citations[0]['locations'], [0])
-        self.assertTrue('url' in citations[0])
+    assert len(citations) == 1
+    assert citations[0] == {
+        'text': 'MAGIC',
+        'citation_type': 'OTHER',
+        'components': {},
+        'url': 'http://example.com/magic',
+        'locations': [0, 2]
+    }
 
-    def test_cfr(self):
-        """Ensure that we successfully parse CFR references."""
-        node = Node("Ref 1: 12 CFR part 1026. Ref 2: 12 CFR 1026.13.",
-                    label=['1003'])
-        citations = ExternalCitationParser(None).process(node)
 
-        cit_1026 = get_citation(citations, '12 CFR part 1026')
-        self.assertEqual(cit_1026['citation_type'], 'CFR')
-        self.assertEqual(cit_1026['components'],
-                         {'cfr_title': '12', 'part': '1026'})
-        self.assertEqual(cit_1026['locations'], [0])
-        self.assertTrue('url' in cit_1026)
+def test_urls():
+    """If text contains http-based urls, they should be tagged"""
+    node = Node("Something http://example.com, not: a url://here "
+                "but https://here.is.something/with?slashes=true.")
+    citations = ExternalCitationParser(None).process(node)
+    urls = ['http://example.com',
+            'https://here.is.something/with?slashes=true']
 
-        cit_1026_13 = get_citation(citations, '12 CFR 1026.13')
-        self.assertEqual(cit_1026_13['citation_type'], 'CFR')
-        self.assertEqual(cit_1026_13['components'],
-                         {'cfr_title': '12', 'part': '1026', 'section': '13'})
-        self.assertEqual(cit_1026_13['locations'], [0])
-        self.assertTrue('url' in cit_1026_13)
-
-    def test_cfr_multiple(self):
-        """Ensure that we successfully parse multiple CFR references."""
-        node = Node("Some text 26 CFR 601.121 through 601.125 some more text",
-                    label=['1003'])
-        citations = ExternalCitationParser(None).process(node)
-
-        cit_601_121 = get_citation(citations, '26 CFR 601.121')
-        self.assertEqual(cit_601_121['citation_type'], 'CFR')
-        self.assertEqual(cit_601_121['components'],
-                         {'cfr_title': '26', 'part': '601', 'section': '121'})
-        self.assertEqual(cit_601_121['locations'], [0])
-        self.assertTrue('url' in cit_601_121)
-
-        cit_601_125 = get_citation(citations, '601.125')
-        self.assertEqual(cit_601_125['citation_type'], 'CFR')
-        self.assertEqual(cit_601_125['components'],
-                         {'cfr_title': '26', 'part': '601', 'section': '125'})
-        self.assertEqual(cit_601_125['locations'], [0])
-        self.assertTrue('url' in cit_601_125)
-
-    def test_drop_self_referential_cfr(self):
-        """
-            Ensure that CFR references that refer to the reg being parsed are
-            not marked as external citations.
-        """
-        node = Node("11 CFR 110.14", label=['110', '1'])
-        citations = ExternalCitationParser(None).process(node)
-        self.assertEqual(None, citations)
-
-    def test_custom(self):
-        """Ensure that custom citations are found. Also verify multiple
-        matches are found and word boundaries respected"""
-        node = Node("This has MAGIC text. Not magic, or MAGICAL, but MAGIC")
-        to_patch = ('regparser.layer.external_types.settings.'
-                    'CUSTOM_CITATIONS')
-
-        with patch.dict(to_patch, {'MAGIC': 'http://example.com/magic'}):
-            citations = ExternalCitationParser(None).process(node)
-
-        self.assertEqual(1, len(citations))
-        self.assertEqual(citations[0], {'text': 'MAGIC',
-                                        'citation_type': 'OTHER',
-                                        'components': {},
-                                        'url': 'http://example.com/magic',
-                                        'locations': [0, 2]})
-
-    def test_urls(self):
-        """If text contains http-based urls, they should be tagged"""
-        node = Node("Something http://example.com, not: a url://here "
-                    "but https://here.is.something/with?slashes=true.")
-        citations = ExternalCitationParser(None).process(node)
-        urls = ['http://example.com',
-                'https://here.is.something/with?slashes=true']
-
-        self.assertEqual(2, len(citations))
-        for url in urls:
-            citation = get_citation(citations, url)
-            self.assertEqual(citation['url'], url)
-            self.assertEqual(citation['text'], url)
+    assert len(citations) == 2
+    for url in urls:
+        citation = get_citation(citations, url)
+        assert citation['url'] == url
+        assert citation['text'] == url


### PR DESCRIPTION
Rather than copy-paste functions, describe them as a configuration of that shared logic. Also rewrites a test file into py.test style.
