### PR TITLE
Standardize the tagged_text attribute

### DIFF
--- a/regparser/layer/def_finders.py
+++ b/regparser/layer/def_finders.py
@@ -120,7 +120,7 @@ class XMLTermMeans(FinderBase):
 
     def find(self, node):
         refs = []
-        tagged_text = getattr(node, 'tagged_text', '')
+        tagged_text = node.tagged_text
         for match, _, _ in grammar.xml_term_parser.scanString(tagged_text):
             """Position in match reflects XML tags, so its dropped in
             preference of new values based on node.text."""
@@ -177,7 +177,7 @@ class DefinitionKeyterm(object):
 
     def find(self, node):
         if self.title_matches:
-            tagged_text = getattr(node, 'tagged_text', '')
+            tagged_text = node.tagged_text
             try:
                 match = grammar.key_term_parser.parseString(tagged_text)
                 phrase = node.tagged_text[match.term.pos[0]:match.term.pos[1]]

--- a/regparser/layer/formatting.py
+++ b/regparser/layer/formatting.py
@@ -255,8 +255,7 @@ def node_to_table_xml_els(node):
     else:
         # tagged_text isn't quite XML -- it's often a fragment with unescaped
         # characters. Clean it up before searching it
-        tagged_text = getattr(node, 'tagged_text', '')
-        tagged_text = tagged_text.replace('&', '&amp;')
+        tagged_text = node.tagged_text.replace('&', '&amp;')
         tagged_text = u'<ROOT>{}</ROOT>'.format(tagged_text)
         root_xml_el = etree.fromstring(tagged_text)
 

--- a/regparser/layer/key_terms.py
+++ b/regparser/layer/key_terms.py
@@ -32,8 +32,7 @@ class KeyTerms(Layer):
 
     @classmethod
     def keyterm_in_node(cls, node, ignore_definitions=True):
-        tagged = (getattr(node, 'tagged_text', None) or '')
-        tagged = tagged.replace(marker_of(node), '', 1).strip()
+        tagged = node.tagged_text.replace(marker_of(node), '', 1).strip()
         keyterm = keyterm_in_text(tagged)
 
         if keyterm and not (ignore_definitions and

--- a/regparser/layer/preamble/key_terms.py
+++ b/regparser/layer/preamble/key_terms.py
@@ -12,6 +12,5 @@ class KeyTerms(BaseKeyTerms):
         (to limit false positives)"""
         marker = marker_of(node)
         if marker:
-            tagged = (getattr(node, 'tagged_text', None) or '')
-            tagged = tagged.replace(marker, '', 1).strip()
+            tagged = node.tagged_text.replace(marker, '', 1).strip()
             return keyterm_in_text(tagged)

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -82,7 +82,7 @@ def node_text_equality(left, right):
         left and right and
         left.text == right.text and
         left.title == right.title and
-        getattr(left, 'tagged_text', '') == getattr(right, 'tagged_text', '')
+        left.tagged_text == right.tagged_text
     )
 
 
@@ -302,8 +302,7 @@ class RegulationTree(object):
         elif existing and is_interp_placeholder(existing):
             existing.title = node.title
             existing.text = node.text
-            if hasattr(node, 'tagged_text'):
-                existing.tagged_text = node.tagged_text
+            existing.tagged_text = node.tagged_text
         # Proceed only if we're not re-adding an existing node (common in our
         # messy data)
         elif not node_text_equality(existing, node):
@@ -361,7 +360,7 @@ class RegulationTree(object):
         node = find(self.tree, label)
         node.text = replace_first_sentence(node.text, change['node']['text'])
 
-        if hasattr(node, 'tagged_text') and 'tagged_text' in change['node']:
+        if node.tagged_text and 'tagged_text' in change['node']:
             node.tagged_text = replace_first_sentence(
                 node.tagged_text, change['node']['tagged_text'])
 

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -22,7 +22,7 @@ class Node(object):
     MARKERLESS_REGEX = re.compile(r'p\d+')
 
     def __init__(self, text='', children=[], label=[], title=None,
-                 node_type=REGTEXT, source_xml=None, tagged_text=None):
+                 node_type=REGTEXT, source_xml=None, tagged_text=''):
 
         self.text = six.text_type(text)
 
@@ -34,11 +34,7 @@ class Node(object):
         self.title = title or None
         self.node_type = node_type
         self.source_xml = source_xml
-        if tagged_text is not None:
-            # Note that parts of the parser use the presence/absence of this
-            # attribute (rather than its value) as an indicator. When that's
-            # no longer the case, we can remove the `if` here
-            self.tagged_text = tagged_text
+        self.tagged_text = tagged_text
 
     def __repr__(self):
         return (("Node( text = %s, children = %s, label = %s, title = %s, " +
@@ -122,10 +118,7 @@ def full_node_decode_hook(d):
     """Convert a JSON object into a full Node"""
     if set(d.keys()) == FullNodeEncoder.FIELDS:
         params = dict(d)
-        del(params['tagged_text'])  # Ugly, but this field is set separately
         node = Node(**params)
-        if d['tagged_text']:
-            node.tagged_text = d['tagged_text']
         if node.source_xml:
             node.source_xml = etree.fromstring(node.source_xml)
         return node
@@ -330,7 +323,7 @@ class FrozenNode(object):
         children = [FrozenNode.from_node(n) for n in node.children]
         fresh = FrozenNode(text=node.text, children=children, label=node.label,
                            title=node.title or '', node_type=node.node_type,
-                           tagged_text=getattr(node, 'tagged_text', '') or '')
+                           tagged_text=node.tagged_text)
         return fresh.prototype()
 
     # @todo - seems like something we could implement via __new__?

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -157,9 +157,10 @@ class AppendixProcessor(object):
         """The paragraph has a marker, like (a) or a. etc."""
         # To aid in determining collapsed paragraphs, replace any
         # keyterms present
-        node_for_keyterms = Node(text, node_type=Node.APPENDIX)
-        node_for_keyterms.tagged_text = tagged_text
-        node_for_keyterms.label = [initial_marker(text)[0]]
+        node_for_keyterms = Node(
+            text, node_type=Node.APPENDIX, tagged_text=tagged_text,
+            label=[initial_marker(text)[0]]
+        )
         keyterm = KeyTerms.keyterm_in_node(node_for_keyterms)
         if keyterm:
             mtext = text.replace(keyterm, '.' * len(keyterm))

--- a/regparser/tree/xml_parser/interpretations.py
+++ b/regparser/tree/xml_parser/interpretations.py
@@ -55,9 +55,10 @@ def collapsed_markers_matches(node_text, tagged_text):
     text but takes cues from the tagged text. @todo: streamline logic"""
     # In addition to the regex above, keyterms are an acceptable prefix. We
     # therefore convert keyterms to satisfy the above regex
-    node_for_keyterms = Node(node_text, node_type=Node.INTERP,
-                             label=[get_first_interp_marker(node_text)])
-    node_for_keyterms.tagged_text = tagged_text
+    node_for_keyterms = Node(
+        node_text, node_type=Node.INTERP, tagged_text=tagged_text,
+        label=[get_first_interp_marker(node_text)]
+    )
     keyterm = KeyTerms.keyterm_in_node(node_for_keyterms)
     if keyterm:
         node_text = node_text.replace(keyterm, '.' * len(keyterm))
@@ -145,7 +146,7 @@ def process_inner_children(inner_stack, xml_node):
                            "previous paragraph: %s", node_text)
             previous = nodes[-1]
             previous.text += "\n\n" + node_text
-            if hasattr(previous, 'tagged_text'):
+            if previous.tagged_text:
                 previous.tagged_text += "\n\n" + text_with_tags
             else:
                 previous.tagged_text = text_with_tags
@@ -173,8 +174,7 @@ def nodes_from_interp_p(xml_node):
 
     #   Node for this paragraph
     n = Node(node_text[0:starts[0]], label=[first_marker],
-             node_type=Node.INTERP)
-    n.tagged_text = text_with_tags
+             node_type=Node.INTERP, tagged_text=text_with_tags)
     yield n
     if n.text.endswith('* * *'):
         yield Node(label=[mtypes.INLINE_STARS])

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -120,11 +120,10 @@ class ParagraphProcessor(object):
         intro_node, nodes = self.separate_intro(nodes)
         if intro_node:
             root.text = " ".join([root.text, intro_node.text]).strip()
-            # @todo - this is ugly. Make tagged_text a legitimate field on Node
             tagged_text_list = []
-            if getattr(root, 'tagged_text', None):
+            if root.tagged_text:
                 tagged_text_list.append(root.tagged_text)
-            if getattr(intro_node, 'tagged_text', None):
+            if intro_node.tagged_text:
                 tagged_text_list.append(intro_node.tagged_text)
             if tagged_text_list:
                 root.tagged_text = ' '.join(tagged_text_list)

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -290,8 +290,8 @@ def build_from_section(reg_part, section_xml):
 
         sect_node = Node(
             section_text, label=[reg_part, section_number],
-            title=section_title)
-        sect_node.tagged_text = tagged_section_text
+            title=section_title, tagged_text=tagged_section_text
+        )
 
         section_nodes.append(
             RegtextParagraphProcessor().process(section_xml, sect_node)
@@ -344,10 +344,10 @@ class ParagraphMatcher(paragraph_processor.BaseMatcher):
         nodes = []
         plain_text = ''
         for marker, plain_text, tagged_text in split_by_markers(xml):
-            node = Node(text=plain_text.strip(), label=[marker],
-                        source_xml=xml)
-            node.tagged_text = six.text_type(tagged_text.strip())
-            nodes.append(node)
+            nodes.append(Node(
+                text=plain_text.strip(), label=[marker], source_xml=xml,
+                tagged_text=six.text_type(tagged_text.strip())
+            ))
 
         if plain_text.endswith('* * *'):    # last in loop
             nodes.append(Node(label=[mtypes.INLINE_STARS]))

--- a/regparser/tree/xml_parser/us_code.py
+++ b/regparser/tree/xml_parser/us_code.py
@@ -38,9 +38,10 @@ class USCodeParagraphMatcher(paragraph_processor.BaseMatcher):
                        tree_utils.split_text(text, with_parens),
                        tree_utils.split_text(tagged_text, with_parens))
         for m, text, tagged_text in triplets:
-            node = Node(text=text.strip(), label=[m], source_xml=xml)
-            node.tagged_text = six.text_type(tagged_text.strip())
-            nodes.append(node)
+            nodes.append(Node(
+                text=text.strip(), label=[m], source_xml=xml,
+                tagged_text=six.text_type(tagged_text.strip())
+            ))
         return nodes
 
 


### PR DESCRIPTION
We had been testing Node objects for the presence of the `tagged_text`
attribute rather than defining that attribute consistently. Simplify a bunch
of logic by using the attribute consistently.

This _may_ require another change related to serialization; will see when the
integration tests run.