### PR TITLE
Add a handful of parsing performance boosts

### DIFF
--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -69,7 +69,9 @@ appendix_with_section = QuickSearchable(
     (atomic.appendix_digit +
      ZeroOrMore(atomic.lower_p | atomic.roman_p | atomic.digit_p |
                 atomic.upper_p)).setParseAction(
-                    appendix_section).setResultsName("appendix_section"))
+                    appendix_section).setResultsName("appendix_section"),
+    # optimization: encode the regex
+    force_regex_str=r"[A-Z]+[0-9]*\b\s*-")
 
 appendix_with_part = QuickSearchable(
     keep_pos(atomic.appendix_marker).setResultsName("marker") +

--- a/regparser/grammar/utils.py
+++ b/regparser/grammar/utils.py
@@ -138,9 +138,10 @@ class QuickSearchable(pyparsing.ParseElementEnhance):
         elif isinstance(grammar, (pyparsing.MatchFirst, pyparsing.Or)):
             return reduce(lambda so_far, expr: so_far | recurse(expr),
                           grammar.exprs, set())
-        elif isinstance(grammar, (pyparsing.Suppress, QuickSearchable)):
+        elif isinstance(grammar, pyparsing.Suppress):
             return recurse(grammar.expr)
-        elif isinstance(grammar, (pyparsing.Regex, pyparsing.Word)):
+        elif isinstance(grammar, (pyparsing.Regex, pyparsing.Word,
+                                  QuickSearchable)):
             return set([grammar.reString])
         elif isinstance(grammar, pyparsing.LineStart):
             return set(['^'])

--- a/regparser/grammar/utils.py
+++ b/regparser/grammar/utils.py
@@ -62,16 +62,20 @@ class QuickSearchable(pyparsing.ParseElementEnhance):
     flexibility, it is rather slow for our needs. This enhanced grammar type
     wraps other grammars, deriving from them a first regular expression to use
     when `scanString`ing. This cuts search time considerably."""
-    def __init__(self, expr):
+    def __init__(self, expr, force_regex_str=None):
         super(QuickSearchable, self).__init__(expr)
         regex_strs = []
-        for regex_str in QuickSearchable.initial_regex(expr):
-            if '|' in regex_str:
-                # If the regex includes an "or", we need to wrap it in parens
-                regex_str = '(' + regex_str + ')'
-            regex_strs.append(regex_str)
-        # Combine all potential initial_regexes with an "or". Match
-        # Pyparsing's naming convention
+        if force_regex_str is not None:
+            regex_strs.append(force_regex_str)
+        else:
+            for regex_str in QuickSearchable.initial_regex(expr):
+                if '|' in regex_str:
+                    # If the regex includes an "or", we need to wrap it in
+                    # parens
+                    regex_str = '(' + regex_str + ')'
+                regex_strs.append(regex_str)
+            # Combine all potential initial_regexes with an "or". Match
+            # Pyparsing's naming convention
         self.reString = '|'.join(regex_strs)
         self.re = re.compile(
             self.reString,

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -47,6 +47,20 @@ class Terms(Layer):
         #   scope -> List[(term, definition_ref)]
         self.scoped_terms = defaultdict(list)
         self.scope_finder = ScopeFinder()
+        self.singulars = {}
+        self.plurals = {}
+
+    def singularize(self, term):
+        """Check the memoized singular version of the provided term"""
+        if term not in self.singulars:
+            self.singulars[term] = inflection.singularize(term)
+        return self.singulars[term]
+
+    def pluralize(self, term):
+        """Check the memoized plural version of the provided term"""
+        if term not in self.plurals:
+            self.plurals[term] = inflection.pluralize(term)
+        return self.plurals[term]
 
     def look_for_defs(self, node, stack=None):
         """Check a node and recursively check its children for terms which are
@@ -186,8 +200,7 @@ class Terms(Layer):
         exclusions.extend(self.ignored_offsets(node.label[0], node.text))
         return exclusions
 
-    @staticmethod
-    def calculate_offsets(text, applicable_terms, exclusions=None,
+    def calculate_offsets(self, text, applicable_terms, exclusions=None,
                           inclusions=None):
         """Search for defined terms in this text, including singular and
         plural forms of these terms, with a preference for all larger
@@ -198,9 +211,9 @@ class Terms(Layer):
         inclusions = list(inclusions or [])
 
         # add singulars and plurals to search terms
-        search_terms = set((inflection.singularize(t[0]), t[1])
+        search_terms = set((self.singularize(t[0]), t[1])
                            for t in applicable_terms)
-        search_terms |= set((inflection.pluralize(t[0]), t[1])
+        search_terms |= set((self.pluralize(t[0]), t[1])
                             for t in applicable_terms)
 
         # longer terms first

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 import re
 
 import inflection
@@ -21,6 +21,7 @@ except ValueError:
 
 
 MAX_TERM_LENGTH = 100
+Inflected = namedtuple('Inflected', ['singular', 'plural'])
 
 
 class ParentStack(PriorityStack):
@@ -47,20 +48,14 @@ class Terms(Layer):
         #   scope -> List[(term, definition_ref)]
         self.scoped_terms = defaultdict(list)
         self.scope_finder = ScopeFinder()
-        self.singulars = {}
-        self.plurals = {}
+        self._inflected = {}
 
-    def singularize(self, term):
-        """Check the memoized singular version of the provided term"""
-        if term not in self.singulars:
-            self.singulars[term] = inflection.singularize(term)
-        return self.singulars[term]
-
-    def pluralize(self, term):
-        """Check the memoized plural version of the provided term"""
-        if term not in self.plurals:
-            self.plurals[term] = inflection.pluralize(term)
-        return self.plurals[term]
+    def inflected(self, term):
+        """Check the memoized Inflected version of the provided term"""
+        if term not in self._inflected:
+            self._inflected[term] = Inflected(
+                inflection.singularize(term), inflection.pluralize(term))
+        return self._inflected[term]
 
     def look_for_defs(self, node, stack=None):
         """Check a node and recursively check its children for terms which are
@@ -211,10 +206,9 @@ class Terms(Layer):
         inclusions = list(inclusions or [])
 
         # add singulars and plurals to search terms
-        search_terms = set((self.singularize(t[0]), t[1])
-                           for t in applicable_terms)
-        search_terms |= set((self.pluralize(t[0]), t[1])
-                            for t in applicable_terms)
+        search_terms = set((inflected, t[1])
+                           for t in applicable_terms
+                           for inflected in self.inflected(t[0]))
 
         # longer terms first
         search_terms = sorted(search_terms, key=lambda x: len(x[0]),

--- a/regparser/web/index/models.py
+++ b/regparser/web/index/models.py
@@ -10,10 +10,19 @@ class Dependency(models.Model):
     depender = models.ForeignKey(DependencyNode, related_name='depends_on')
 
 
+class EntryManager(models.Manager):
+    """We usually don't intend to deserialize the binary (often quite large)
+    "contents" field, so defer its inclusion by default"""
+    def get_queryset(self):
+        return super(EntryManager, self).get_queryset().defer('contents')
+
+
 class Entry(models.Model):
     label = models.OneToOneField(DependencyNode, primary_key=True)
     modified = models.DateTimeField(auto_now=True)
     contents = models.BinaryField()
+
+    objects = EntryManager()
 
     class Meta:
         ordering = ['label']


### PR DESCRIPTION
I used kcachegrind to inspect the results of a run on 27 CFR 478's full history and tried to optimize the biggest pain points. This led to four changes:
* Caching the results of singular/plural lookups
* Refraining from fetching Entry.contents for all entries
* Allow QuickSearchable's to have hard-coded regexes (to be more descriptive)
* Re-use QuickSearchable's parsed regex