### PR TITLE
Bump version for quarterly release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regparser",
-    version="4.2.0",
+    version="4.3.0",
     packages=find_packages(),
     classifiers=[
         'License :: Public Domain',


### PR DESCRIPTION
Changes should be backwards compatible, but we have a few new features, so this is just a minor version bump.

- Fix docker build #362
- #361: removing deprecated --http_cache parameter #363
- Three parsing tweaks from #355 #359
- Handful of fixes for 37 CFR 42 #357
- Use FR volume/page instead of publication date when sorting #354
- Fixes for EPA integration tests #353
- Use unicode literals when parsing super/subtext #352
- Add command for full-issuance/reissuances #351
- Step 4 of separating out interpretations #349
- Add a handful of flake8 plugins #346
- Separate interpretations part 3 #344