### PR TITLE
#364: WHED appendix title handling rewritten to complement #359

### DIFF
--- a/interpparser/gpo_cfr.py
+++ b/interpparser/gpo_cfr.py
@@ -11,7 +11,7 @@ from regparser.layer.key_terms import KeyTerms
 from regparser.tree.depth import markers as mtypes
 from regparser.tree.depth import heuristics, rules
 from regparser.tree.depth.derive import derive_depths
-from regparser.tree.gpo_cfr.appendices import appendix_headers
+from regparser.tree.gpo_cfr import appendices
 from regparser.tree.struct import Node, treeify
 from regparser.tree.xml_parser import matchers, tree_utils
 
@@ -292,11 +292,10 @@ def parse_from_xml(root, xml_nodes):
 
 def build_supplement_tree(reg_part, node):
     """ Build the tree for the supplement section. """
-    title = tree_utils.get_node_text(appendix_headers(node)[0])
     root = Node(
         node_type=Node.INTERP,
         label=[reg_part, Node.INTERP_MARK],
-        title=title)
+        title=appendices.get_appendix_title(node))
 
     return parse_from_xml(root, node.getchildren())
 
@@ -304,14 +303,3 @@ def build_supplement_tree(reg_part, node):
 @matchers.match_tag('INTERP')
 def parse_interp(parent, xml_node):
     parent.children.append(build_supplement_tree(parent.cfr_part, xml_node))
-
-
-def get_app_title(node):
-    """ Appendix/Supplement sections have the title in an HD tag, or
-    if they are reserved, in a <RESERVED> tag. Extract the title. """
-
-    titles = node.xpath("./HD[@SOURCE='HED']")
-    if titles:
-        return titles[0].text
-    else:
-        return node.xpath("./RESERVED")[0]

--- a/interpparser/gpo_cfr.py
+++ b/interpparser/gpo_cfr.py
@@ -291,7 +291,7 @@ def parse_from_xml(root, xml_nodes):
 
 
 def build_supplement_tree(reg_part, node):
-    """ Build the tree for the supplement section. """
+    """Build the tree for the supplement section."""
     root = Node(
         node_type=Node.INTERP,
         label=[reg_part, Node.INTERP_MARK],

--- a/interpparser/preprocessors.py
+++ b/interpparser/preprocessors.py
@@ -26,7 +26,7 @@ def supplement_amdpar(xml):
 
 
 def appendix_to_interp(xml):
-    """Convert Supplement I APPENDIX tags to INTERP"""
+    """Convert Supplement I APPENDIX tags to INTERP."""
     for appendix in xml.xpath('.//APPENDIX'):
         section_title = appendices.get_appendix_title(appendix)
         if 'Supplement' in section_title and 'Part' in section_title:

--- a/interpparser/preprocessors.py
+++ b/interpparser/preprocessors.py
@@ -1,4 +1,4 @@
-from interpparser.gpo_cfr import get_app_title
+from regparser.tree.gpo_cfr import appendices
 
 _CONTAINS_SUPPLEMENT = "contains(., 'Supplement I')"
 _SUPPLEMENT_HD = "//REGTEXT//HD[@SOURCE='HD1' and {0}]".format(
@@ -28,6 +28,6 @@ def supplement_amdpar(xml):
 def appendix_to_interp(xml):
     """Convert Supplement I APPENDIX tags to INTERP"""
     for appendix in xml.xpath('.//APPENDIX'):
-        section_title = get_app_title(appendix)
+        section_title = appendices.get_appendix_title(appendix)
         if 'Supplement' in section_title and 'Part' in section_title:
             appendix.tag = 'INTERP'

--- a/regparser/tree/gpo_cfr/appendices.py
+++ b/regparser/tree/gpo_cfr/appendices.py
@@ -49,6 +49,7 @@ def appendix_headers(node):
     """ Retrieve Appendix/Supplement section HD, WHED, and RESERVED tags. """
     return node.xpath('./RESERVED|./HD[@SOURCE="HED"]|./WHED')
 
+
 def get_appendix_title(node):
     """ Retrieve the first Appendix/Supplement title from its headers. """
     return tree_utils.get_node_text(appendix_headers(node)[0])

--- a/regparser/tree/gpo_cfr/appendices.py
+++ b/regparser/tree/gpo_cfr/appendices.py
@@ -46,7 +46,12 @@ def remove_toc(appendix, letter):
 
 
 def appendix_headers(node):
+    """ Retrieve Appendix/Supplement section HD, WHED, and RESERVED tags. """
     return node.xpath('./RESERVED|./HD[@SOURCE="HED"]|./WHED')
+
+def get_appendix_title(node):
+    """ Retrieve the first Appendix/Supplement title from its headers. """
+    return tree_utils.get_node_text(appendix_headers(node)[0])
 
 
 _first_markers = [re.compile(r'[\)\.|,|;|-|—]\s*\(' + lvl[0] + r'\)')


### PR DESCRIPTION
Based on @cmc333333's [comments](https://github.com/eregs/regulations-parser/pull/365#issuecomment-290421748) on #365, I've added a `get_appendix_title` function to `regparser/tree/gpo_cfr/appendices.py`, removed `get_app_title` from `interpparser/gpo_cfr.py`, and replaced all references.