### PR TITLE
Mirroring PR #370 for Interpretations

### DIFF
--- a/interpparser/amendments.py
+++ b/interpparser/amendments.py
@@ -16,7 +16,7 @@ def content_for_interpretations(instruction_xml):
     """Return a chunk of XML (which serves as a unique key) and a think for
     parsing that XML as an interpretation"""
     label_parts, amdpar = label_amdpar_from(instruction_xml)
-    if len(label_parts) > 0 and 'Interpretations' in label_parts[1]:
+    if len(label_parts) > 1 and 'Interpretations' in label_parts[1]:
         xml = amdpar.getparent()
         return xml, functools.partial(parse_interp, label_parts[0], xml)
 

--- a/regparser/notice/amendments/appendix.py
+++ b/regparser/notice/amendments/appendix.py
@@ -13,7 +13,7 @@ def content_for_appendix(instruction_xml):
     """Return a chunk of XML (which serves as a unique key) and a think for
     parsing that XML as an appendix"""
     label_parts, amdpar = label_amdpar_from(instruction_xml)
-    if len(label_parts) > 0 and 'Appendix' in label_parts[1]:
+    if len(label_parts) > 1 and 'Appendix' in label_parts[1]:
         xml = amdpar.getparent()
         letter = label_parts[1][len('Appendix:'):]
         return xml, functools.partial(parse_appendix, xml, label_parts[0],

--- a/tests/interpparser/amendments_tests.py
+++ b/tests/interpparser/amendments_tests.py
@@ -116,3 +116,12 @@ def test_process_amendments_restart_new_section(monkeypatch):
 
     assert changes1['104-22-a-Interp'][0]['action'] == 'POST'
     assert changes2['105-1-b'][0]['action'] == 'PUT'
+
+
+def test_content_for_interpretations_regression_369():
+    """Regression test for modifications to a top-level element"""
+    with XMLBuilder('EREGS_INSTRUCTIONS', final_context='2-?-201') as ctx:
+        ctx.POST(label='2[title]')
+        ctx.POST(label='2-?-200')
+        ctx.POST(label='2-?-201')
+    assert amendments.content_for_interpretations(ctx.xml) is None

--- a/tests/notice/amendments/appendix_tests.py
+++ b/tests/notice/amendments/appendix_tests.py
@@ -63,3 +63,12 @@ def test_process_amendments_context(monkeypatch):
     assert amd2['cfr_part'] == '106'
     assert ['106-1-a'] == [c[0] for c in amd1['changes']]
     assert ['106-C', '106-C-p1'] == list(sorted(c[0] for c in amd2['changes']))
+
+
+def test_content_for_appendix_regression_369():
+    """Regression test for modifications to a top-level element"""
+    with XMLBuilder('EREGS_INSTRUCTIONS', final_context='2-?-201') as ctx:
+        ctx.POST(label='2[title]')
+        ctx.POST(label='2-?-200')
+        ctx.POST(label='2-?-201')
+    assert appendix.content_for_appendix(ctx.xml) is None


### PR DESCRIPTION
PR #370 fixes the issue with the `content_for_appendix()` function in `regparser/notice/amendments/appendix.py`.  The same issue crops up in `content_for_interpretations()` in [`interpparser/amendments.py:19`](https://github.com/eregs/regulations-parser/blob/master/interpparser/amendments.py#L19).  This PR mirrors the fix in #370, including a test.