### PR TITLE
#369: adding try/except to amendments getter

### DIFF
--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -336,7 +336,16 @@ class NoticeXML(XMLWrapper):
 
     @cached_property        # rather expensive operation, so cache results
     def amendments(self):
-        return fetch_amendments(self.xml)
+        """Getter for relevent amendments.
+
+        :rtype: list of amendments
+        """
+        try:
+            amendments = fetch_amendments(self.xml)
+        except:
+            logger.error('Unable to fetch amendments for docket %s', self.version_id)
+            return []
+        return amendments
 
     @property
     def fr_citation(self):

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -342,8 +342,8 @@ class NoticeXML(XMLWrapper):
         """
         try:
             amendments = fetch_amendments(self.xml)
-        except:
-            logger.error('Unable to fetch amendments for docket %s', self.version_id)
+        except:             # noqa
+            logger.error('Unable to fetch amendments for %s', self.version_id)
             return []
         return amendments
 


### PR DESCRIPTION
Per [@cmc333333's guidance](https://github.com/eregs/regulations-parser/issues/369#issuecomment-297752194), adding a `try/except` block around the `amendments` getter for the `NoticeXML` class.  This enables bypassing of parsing errors in other CFR parts.